### PR TITLE
fix: use urlPath in dir listing page

### DIFF
--- a/lib/pages.js
+++ b/lib/pages.js
@@ -1,10 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
-import { clamp, escapeHtml, fwdSlash, getDirname, trimSlash } from './utils.js';
+import { clamp, escapeHtml, getDirname, trimSlash } from './utils.js';
 
 /**
 @typedef {import('./types.js').DirIndexItem} DirIndexItem
+@typedef {import('./types.js').ResolvedFile} ResolvedFile
 @typedef {import('./types.js').ServerOptions} ServerOptions
 **/
 
@@ -89,23 +90,23 @@ export function errorPage({ status, urlPath }) {
 }
 
 /**
- * @param {{ filePath: string; localPath: string; items: DirIndexItem[] }} data
+ * @param {{ urlPath: string; file: ResolvedFile; items: DirIndexItem[] }} data
  * @param {Pick<ServerOptions, 'root' | 'ext'>} options
  * @returns {Promise<string>}
  */
-export function dirListPage({ filePath, localPath, items }, options) {
+export function dirListPage({ urlPath, file, items }, options) {
 	const rootName = basename(options.root);
-	const dirPath = trimSlash(fwdSlash(localPath));
-	const baseUrl = dirPath ? `/${dirPath}/` : '/';
+	const trimmedUrl = trimSlash(urlPath);
+	const baseUrl = trimmedUrl ? `/${trimmedUrl}/` : '/';
 
-	const displayPath = decodeURIPathSegments(dirPath ? `${rootName}/${dirPath}` : rootName);
+	const displayPath = decodeURIPathSegments(trimmedUrl ? `${rootName}/${trimmedUrl}` : rootName);
 
 	const sorted = [...items.filter((x) => isDirLike(x)), ...items.filter((x) => !isDirLike(x))];
 
-	if (dirPath) {
+	if (trimmedUrl !== '') {
 		sorted.unshift({
-			filePath: dirname(filePath),
-			localPath: dirname(localPath),
+			filePath: dirname(file.filePath),
+			localPath: file.localPath && dirname(file.localPath),
 			kind: 'dir',
 			isParent: true,
 		});

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,5 @@
 import { open } from 'node:fs/promises';
 import { createServer } from 'node:http';
-import { join } from 'node:path';
 
 import { getContentType, typeForFilePath } from './content-type.js';
 import { fsUtils } from './node-fs.js';
@@ -11,6 +10,7 @@ import { FileResolver, PathMatcher } from './resolver.js';
 @typedef {import('./types.js').DirIndexItem} DirIndexItem
 @typedef {import('./types.js').FSEntryKind} FSEntryKind
 @typedef {import('./types.js').ReqResInfo} ReqResInfo
+@typedef {import('./types.js').ResolvedFile} ResolvedFile
 @typedef {import('./types.js').ResolveResult} ResolveResult
 @typedef {import('./types.js').ServerOptions} ServerOptions
 **/
@@ -93,16 +93,8 @@ export function staticServer(options, { logNetwork }) {
 			file.filePath != null &&
 			file.localPath != null
 		) {
-			await sendDirListPage(
-				res,
-				{
-					status: result.status,
-					filePath: file.filePath,
-					localPath: file.localPath,
-					items: await resolver.index(file.filePath),
-				},
-				options,
-			);
+			const items = await resolver.index(file.filePath);
+			await sendDirListPage(res, { ...result, file, items }, options);
 		}
 
 		// show an error page
@@ -114,25 +106,18 @@ export function staticServer(options, { logNetwork }) {
 
 /**
  * @param {import('node:http').ServerResponse} res
- * @param {{ status: number, filePath: string; localPath: string; items: DirIndexItem[] }} data
+ * @param {{ status: number, urlPath: string; file: ResolvedFile; items: DirIndexItem[] }} data
  * @param {ServerOptions} options
  */
-async function sendDirListPage(res, data, options) {
+async function sendDirListPage(res, { status, urlPath, file, items }, options) {
 	const headers = fileHeaders({
-		localPath: join(data.localPath, 'index.html'),
+		localPath: 'index.html',
 		// ignore user options for directory listings
 		cors: false,
 		headers: [],
 	});
-	const body = await dirListPage(
-		{
-			filePath: data.filePath,
-			localPath: data.localPath,
-			items: data.items,
-		},
-		options,
-	);
-	res.writeHead(data.status, headers);
+	const body = await dirListPage({ urlPath, file, items }, options);
+	res.writeHead(status, headers);
 	res.write(body);
 	res.end();
 }

--- a/test/resolver.test.js
+++ b/test/resolver.test.js
@@ -2,13 +2,7 @@ import { deepStrictEqual, strictEqual, throws } from 'node:assert';
 import { suite, test } from 'node:test';
 
 import { FileResolver, PathMatcher } from '../lib/resolver.js';
-import {
-	defaultResolveOptions,
-	getFsUtils,
-	getResolver,
-	indexItem,
-	testPath as root,
-} from './shared.js';
+import { defaultResolveOptions, file, getFsUtils, getResolver, root } from './shared.js';
 
 suite('PathMatcher', () => {
 	test('does not match strings when no patterns are provided', () => {
@@ -298,7 +292,7 @@ suite('FileResolver.find', () => {
 			deepStrictEqual(await resolver.find(url), {
 				urlPath: url,
 				status: readable ? 200 : 403,
-				file: indexItem('file', localPath),
+				file: file(localPath),
 			});
 		}
 	});
@@ -311,7 +305,7 @@ suite('FileResolver.find', () => {
 			deepStrictEqual(result, {
 				status: 200,
 				urlPath,
-				file: indexItem('dir', 'section'),
+				file: file('section', 'dir'),
 			});
 		}
 	});
@@ -336,7 +330,7 @@ suite('FileResolver.find', () => {
 			deepStrictEqual(await resolver.find(urlPath), {
 				urlPath,
 				status: 403,
-				file: indexItem('file', localPath),
+				file: file(localPath),
 			});
 		}
 	});
@@ -366,14 +360,14 @@ suite('FileResolver.find', () => {
 		deepStrictEqual(await resolver.find('/'), {
 			urlPath: '/',
 			status: 200,
-			file: indexItem('file', 'index.html'),
+			file: file('index.html'),
 		});
 
 		for (const urlPath of ['/section', '/section/']) {
 			deepStrictEqual(await resolver.find(urlPath), {
 				urlPath,
 				status: 200,
-				file: indexItem('file', 'section/index.html'),
+				file: file('section/index.html'),
 			});
 		}
 	});
@@ -387,7 +381,7 @@ suite('FileResolver.find', () => {
 			deepStrictEqual(await resolver.find(urlPath), {
 				urlPath,
 				status: 200,
-				file: indexItem('file', `${fileLike}.html`),
+				file: file(`${fileLike}.html`),
 			});
 		}
 
@@ -426,17 +420,17 @@ suite('FileResolver.index', () => {
 	test('indexes directories when options.dirList is true', async () => {
 		const resolver = getResolver({ ...defaultResolveOptions }, index_files);
 		deepStrictEqual(await resolver.index(root()), [
-			indexItem('dir', '.well-known'),
-			indexItem('file', 'about-us.html'),
-			indexItem('file', 'index.html'),
-			indexItem('file', 'products.html'),
-			indexItem('dir', 'section'),
+			file('.well-known', 'dir'),
+			file('about-us.html'),
+			file('index.html'),
+			file('products.html'),
+			file('section', 'dir'),
 		]);
 
 		deepStrictEqual(await resolver.index(root`section`), [
-			indexItem('file', 'section/forbidden.json'),
-			indexItem('file', 'section/index.html'),
-			indexItem('file', 'section/page.md'),
+			file('section/forbidden.json'),
+			file('section/index.html'),
+			file('section/page.md'),
 		]);
 	});
 });


### PR DESCRIPTION
The directory listing pages used the `urlPath` to construct the page title and breadcrumbs, but in recent refactoring I switched to using the `file.localPath` instead.

Trouble is, if the URL matches a symlink, we want to keep the page title and breadcrumbs looking like the URL path, and not the symlink's target path.