### PR TITLE
feat: handle HEAD and OPTIONS requests

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -106,7 +106,7 @@ export class CLIArgs {
 		return keys;
 	}
 
-	get data() {
+	data() {
 		return structuredClone({
 			map: this.#map,
 			list: this.#list,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@ import { emitKeypressEvents } from 'node:readline';
 import { CLIArgs } from './args.js';
 import { CLI_OPTIONS, HOSTS_LOCAL, HOSTS_WILDCARD } from './constants.js';
 import { logger, requestLogLine } from './logger.js';
-import { readPkgJson } from './node-fs.js';
+import { readPkgJson } from './fs-proxy.js';
 import { serverOptions } from './options.js';
 import { staticServer } from './server.js';
 import { color, clamp, isPrivateIPv4 } from './utils.js';
@@ -14,6 +14,7 @@ import { color, clamp, isPrivateIPv4 } from './utils.js';
 /**
 @typedef {import('./types.js').OptionName} OptionName
 @typedef {import('./types.js').OptionSpec} OptionSpec
+@typedef {import('./types.js').ListenOptions} ListenOptions
 @typedef {import('./types.js').ServerOptions} ServerOptions
 **/
 
@@ -49,7 +50,7 @@ export async function run() {
 }
 
 export class CLIServer {
-	/** @type {ServerOptions} */
+	/** @type {ListenOptions & ServerOptions} */
 	#options;
 
 	/** @type {number | undefined} */
@@ -62,7 +63,7 @@ export class CLIServer {
 	#server;
 
 	/**
-	 * @param {ServerOptions} options
+	 * @param {ListenOptions & ServerOptions} options
 	 */
 	constructor(options) {
 		this.#options = options;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -29,6 +29,9 @@ export const PORTS_CONFIG = Object.freeze({
 	countLimit: 100,
 });
 
+/** @type {string[]} */
+export const SUPPORTED_METHODS = ['GET', 'HEAD', 'OPTIONS', 'POST'];
+
 /** @type {Record<OptionName, OptionSpec>} */
 export const CLI_OPTIONS = Object.freeze({
 	cors: {

--- a/lib/fs-proxy.js
+++ b/lib/fs-proxy.js
@@ -1,14 +1,15 @@
-import { access, constants, lstat, readdir, realpath } from 'node:fs/promises';
+import { access, constants, lstat, open, readdir, readFile, realpath } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { join, relative, sep as dirSep } from 'node:path';
+import { join, sep as dirSep } from 'node:path';
+
+import { getDirname } from './utils.js';
 
 /**
- * @type {import('./types.js').FSUtils}
+ * @type {import('./types.js').FSProxy}
  */
-export const fsUtils = {
+export const fsProxy = {
 	dirSep,
 	join,
-	relative,
 	async index(dirPath) {
 		try {
 			const entries = await readdir(dirPath, { withFileTypes: true });
@@ -33,6 +34,9 @@ export const fsUtils = {
 			return null;
 		}
 	},
+	async open(filePath) {
+		return open(filePath);
+	},
 	async readable(filePath, kind) {
 		if (kind === undefined) {
 			kind = await this.kind(filePath);
@@ -45,6 +49,9 @@ export const fsUtils = {
 			);
 		}
 		return false;
+	},
+	async readFile(filePath) {
+		return readFile(filePath);
 	},
 	async realpath(filePath) {
 		try {
@@ -60,7 +67,7 @@ export const fsUtils = {
  * @param {import('node:fs').Dirent | import('node:fs').StatsBase<any>} stats
  * @returns {import('./types.js').FSEntryKind | null}
  */
-function statsKind(stats) {
+export function statsKind(stats) {
 	if (stats.isSymbolicLink()) return 'link';
 	if (stats.isDirectory()) return 'dir';
 	else if (stats.isFile()) return 'file';
@@ -72,4 +79,14 @@ function statsKind(stats) {
  */
 export function readPkgJson() {
 	return createRequire(import.meta.url)('../package.json');
+}
+
+/**
+ * @param {string} localPath
+ * @param {NodeJS.BufferEncoding} [encoding]
+ * @returns {Promise<string | import('node:buffer').Buffer>}
+ */
+export async function readPkgFile(localPath, encoding = 'utf8') {
+	const fullPath = join(getDirname(import.meta.url), '..', localPath);
+	return readFile(fullPath, { encoding });
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -5,6 +5,7 @@ import { color, clamp, fwdSlash, withResolvers, trimSlash } from './utils.js';
 
 /**
 @typedef {import('./types.js').ErrorMessage} ErrorMessage
+@typedef {import('./types.js').ReqResMeta} ReqResMeta
 
 @typedef {{
 	group: 'header' | 'info' | 'request' | 'error';
@@ -95,21 +96,22 @@ class Logger {
 export const logger = new Logger();
 
 /**
- * @param {import('./types.js').ReqResInfo} info
+ * @param {ReqResMeta} data
  * @returns {string}
  */
-export function requestLogLine({ startedAt, endedAt, status, method, urlPath, localPath, error }) {
+export function requestLogLine({ startedAt, endedAt, status, method, urlPath, file, error }) {
 	const { brackets, style } = color;
 
 	const isSuccess = status >= 200 && status < 300;
 	const timestamp = new Date(endedAt ?? startedAt).toTimeString().split(' ')[0]?.padStart(8);
 
 	let displayPath = style(urlPath, 'cyan');
-	if (isSuccess && localPath) {
+	if (isSuccess && file?.localPath) {
 		const basePath = urlPath.length > 1 ? trimSlash(urlPath, { end: true }) : urlPath;
-		const suffix = pathSuffix(basePath, `/${fwdSlash(localPath)}`);
+		const suffix = pathSuffix(basePath, `/${fwdSlash(file.localPath)}`);
 		if (suffix) {
 			displayPath = style(basePath, 'cyan') + brackets(suffix, 'dim,gray,dim');
+			if (urlPath.length > 1 && urlPath.endsWith('/')) displayPath += style('/', 'cyan');
 		}
 	}
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -17,6 +17,7 @@ import { errorsContext, intRange } from './utils.js';
 @typedef {import('./types.js').ErrorMessage} ErrorMessage
 @typedef {import('./types.js').HttpHeaderRule} HttpHeaderRule
 @typedef {import('./types.js').PortsConfig} PortsConfig
+@typedef {import('./types.js').ListenOptions} ListenOptions
 @typedef {import('./types.js').ServerOptions} ServerOptions
 @typedef {import('./utils.js').ErrorsContext & { mode: 'arg' | 'option' }} ValidationContext
 **/
@@ -36,9 +37,9 @@ export function validateArgPresence(args, { warn }) {
 }
 
 /**
- * @param {Partial<ServerOptions>} options
+ * @param {Partial<ListenOptions & ServerOptions>} options
  * @param {CLIArgs} [args]
- * @returns {{errors: ErrorMessage[]; options: ServerOptions}}
+ * @returns {{errors: ErrorMessage[]; options: ListenOptions & ServerOptions}}
  */
 export function serverOptions(options, args) {
 	const mode = args ? 'arg' : 'option';

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
+import { readPkgFile } from './fs-proxy.js';
 import { clamp, escapeHtml, getDirname, trimSlash } from './utils.js';
 
 /**
@@ -18,19 +19,16 @@ const attr = (s = '') => escapeHtml(s, 'attr');
 const assetCache = new Map();
 
 /**
- * @param {string} file
+ * @param {string} localPath
  * @returns {Promise<string>}
  */
-async function readAsset(file) {
-	const fullPath = join(getDirname(import.meta.url), file);
-	const cached = assetCache.get(fullPath);
-	if (cached) {
-		return cached;
-	} else {
-		const contents = await readFile(fullPath, { encoding: 'utf8' });
-		assetCache.set(fullPath, contents);
-		return contents;
+export async function readAsset(localPath) {
+	if (!assetCache.has(localPath)) {
+		const result = await readPkgFile(localPath, 'utf8');
+		const text = typeof result === 'string' ? result : '';
+		assetCache.set(localPath, text);
 	}
+	return assetCache.get(localPath) ?? '';
 }
 
 /**
@@ -39,9 +37,9 @@ async function readAsset(file) {
  */
 async function htmlTemplate({ base, body, icon, title }) {
 	const [css, svgSprite, svgIcon] = await Promise.all([
-		readAsset('assets/styles.css'),
-		readAsset('assets/icons.svg'),
-		icon === 'list' || icon === 'error' ? readAsset(`assets/favicon-${icon}.svg`) : undefined,
+		readAsset('lib/assets/styles.css'),
+		readAsset('lib/assets/icons.svg'),
+		icon === 'list' || icon === 'error' ? readAsset(`lib/assets/favicon-${icon}.svg`) : undefined,
 	]);
 
 	return `<!doctype html>
@@ -68,25 +66,25 @@ ${body}
  */
 export function errorPage({ status, urlPath }) {
 	const displayPath = decodeURIPathSegments(urlPath);
+	const pathHtml = `<code class="filepath">${html(displayPath)}</code>`;
 
-	let title = 'Error';
-	let desc = 'Something went wrong';
-	if (status === 403) {
-		title = '403: Forbidden';
-		desc = `Could not access <code class="filepath">${html(displayPath)}</code>`;
-	} else if (status === 404) {
-		title = '404: Not found';
-		desc = `Could not find <code class="filepath">${html(displayPath)}</code>`;
-	} else if (status === 500) {
-		title = '500: Error';
-		desc = `Could not serve <code class="filepath">${html(displayPath)}</code>`;
+	const page = (title = '', desc = '') => {
+		const body = `<h1>${html(title)}</h1>\n<p>${desc}</p>\n`;
+		return htmlTemplate({ icon: 'error', title, body });
+	};
+
+	switch (status) {
+		case 403:
+			return page('403: Forbidden', `Could not access ${pathHtml}`);
+		case 404:
+			return page('404: Not found', `Could not find ${pathHtml}`);
+		case 405:
+			return page('405: Method not allowed');
+		case 500:
+			return page('500: Error', `Could not serve ${pathHtml}`);
+		default:
+			return page('Error', 'Something went wrong');
 	}
-
-	return htmlTemplate({
-		title,
-		icon: 'error',
-		body: `<h1>${html(title)}</h1>\n<p>${desc}</p>\n`,
-	});
 }
 
 /**

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -4,9 +4,9 @@ import { fwdSlash, trimSlash } from './utils.js';
 @typedef {import('./types.js').DirIndexItem} DirIndexItem
 @typedef {import('./types.js').FSEntryBase} FSEntryBase
 @typedef {import('./types.js').FSEntryKind} FSEntryKind
-@typedef {import('./types.js').FSUtils} FSUtils
-@typedef {import('./types.js').ResolveOptions} ResolveOptions
+@typedef {import('./types.js').FSProxy} FSProxy
 @typedef {import('./types.js').ResolveResult} ResolveResult
+@typedef {import('./types.js').ServerOptions} ServerOptions
 **/
 
 export class FileResolver {
@@ -25,14 +25,14 @@ export class FileResolver {
 	/** @type {PathMatcher} */
 	#excludeMatcher;
 
-	/** @type {FSUtils} */
-	#fsUtils;
+	/** @type {FSProxy} */
+	#fs;
 
 	/**
-	 * @param {{root: string } & Partial<ResolveOptions>} options
-	 * @param {FSUtils} fsUtils
+	 * @param {{root: string } & Partial<ServerOptions>} options
+	 * @param {FSProxy} fsProxy
 	 */
-	constructor({ root, ext, dirFile, dirList, exclude }, fsUtils) {
+	constructor({ root, ext, dirFile, dirList, exclude }, fsProxy) {
 		if (typeof root !== 'string') {
 			throw new Error('Missing root directory');
 		}
@@ -41,7 +41,21 @@ export class FileResolver {
 		if (Array.isArray(dirFile)) this.#dirFile = dirFile;
 		if (typeof dirList === 'boolean') this.#dirList = dirList;
 		this.#excludeMatcher = new PathMatcher(exclude ?? [], { caseSensitive: true });
-		this.#fsUtils = fsUtils;
+		this.#fs = fsProxy;
+	}
+
+	/**
+	 * @param {string} filePath
+	 */
+	async open(filePath) {
+		return this.#fs.open(filePath);
+	}
+
+	/**
+	 * @param {string} filePath
+	 */
+	async read(filePath) {
+		return this.#fs.readFile(filePath);
 	}
 
 	/**
@@ -68,8 +82,8 @@ export class FileResolver {
 		const isSymlink = resource.kind === 'link';
 
 		if (isSymlink) {
-			const filePath = await this.#fsUtils.realpath(resource.filePath);
-			const kind = filePath ? await this.#fsUtils.kind(filePath) : null;
+			const filePath = await this.#fs.realpath(resource.filePath);
+			const kind = filePath ? await this.#fs.kind(filePath) : null;
 			if (filePath) {
 				resource = { filePath, kind };
 			}
@@ -87,7 +101,7 @@ export class FileResolver {
 			const enabled = resource.kind === 'file' || (resource.kind === 'dir' && this.#dirList);
 
 			if (enabled && this.allowedPath(localPath)) {
-				const readable = await this.#fsUtils.readable(resource.filePath, resource.kind);
+				const readable = await this.#fs.readable(resource.filePath, resource.kind);
 				result.status = readable ? 200 : 403;
 			} else if (isSymlink) {
 				result.status = 403;
@@ -104,7 +118,7 @@ export class FileResolver {
 	 * @returns {Promise<FSEntryBase>}
 	 */
 	async locateFile(targetPath) {
-		const targetKind = await this.#fsUtils.kind(targetPath);
+		const targetKind = await this.#fs.kind(targetPath);
 
 		if (targetKind === 'file' || targetKind === 'link') {
 			return { kind: targetKind, filePath: targetPath };
@@ -113,13 +127,13 @@ export class FileResolver {
 		/** @type {string[]} */
 		let candidates = [];
 		if (targetKind === 'dir' && this.#dirFile.length) {
-			candidates = this.#dirFile.map((name) => this.#fsUtils.join(targetPath, name));
+			candidates = this.#dirFile.map((name) => this.#fs.join(targetPath, name));
 		} else if (targetKind === null && this.#ext.length) {
 			candidates = this.#ext.map((ext) => targetPath + ext);
 		}
 
 		for (const filePath of candidates) {
-			const kind = await this.#fsUtils.kind(filePath);
+			const kind = await this.#fs.kind(filePath);
 			if (kind === 'file' || kind === 'link') {
 				return { kind, filePath };
 			}
@@ -160,7 +174,7 @@ export class FileResolver {
 		/** @type {DirIndexItem[]} */
 		const items = [];
 
-		for (const { kind, filePath } of await this.#fsUtils.index(dirPath)) {
+		for (const { kind, filePath } of await this.#fs.index(dirPath)) {
 			const localPath = this.localPath(filePath);
 			if (kind != null && this.allowedPath(localPath)) {
 				items.push({ filePath, localPath, kind });
@@ -173,8 +187,8 @@ export class FileResolver {
 			items.map(async (item) => {
 				// resolve symlinks
 				if (item.kind === 'link') {
-					const filePath = await this.#fsUtils.realpath(item.filePath);
-					const kind = filePath ? await this.#fsUtils.kind(filePath) : null;
+					const filePath = await this.#fs.realpath(item.filePath);
+					const kind = filePath ? await this.#fs.kind(filePath) : null;
 					if (filePath != null && kind != null) {
 						item.target = {
 							kind,
@@ -208,7 +222,7 @@ export class FileResolver {
 	 */
 	urlToTargetPath(urlPath) {
 		if (urlPath && urlPath.startsWith('/')) {
-			const filePath = this.#fsUtils.join(this.#root, decodeURIComponent(urlPath));
+			const filePath = this.#fs.join(this.#root, decodeURIComponent(urlPath));
 			return trimSlash(filePath, { end: true });
 		}
 		return null;
@@ -232,7 +246,7 @@ export class FileResolver {
 	 */
 	withinRoot(filePath) {
 		if (filePath.includes('..')) return false;
-		const prefix = this.#root + this.#fsUtils.dirSep;
+		const prefix = this.#root + this.#fs.dirSep;
 		return filePath === this.#root || filePath.startsWith(prefix);
 	}
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,165 +1,343 @@
-import { open } from 'node:fs/promises';
+import { Buffer } from 'node:buffer';
 import { createServer } from 'node:http';
 
+import { SUPPORTED_METHODS } from './constants.js';
 import { getContentType, typeForFilePath } from './content-type.js';
-import { fsUtils } from './node-fs.js';
+import { fsProxy } from './fs-proxy.js';
 import { dirListPage, errorPage } from './pages.js';
 import { FileResolver, PathMatcher } from './resolver.js';
+import { headerCase, strBytes } from './utils.js';
 
 /**
+@typedef {import('node:fs/promises').FileHandle} FileHandle
+@typedef {import('node:http').IncomingMessage} IncomingMessage
+@typedef {import('node:http').Server} Server
+@typedef {import('node:http').ServerResponse} ServerResponse
 @typedef {import('./types.js').DirIndexItem} DirIndexItem
 @typedef {import('./types.js').FSEntryKind} FSEntryKind
-@typedef {import('./types.js').ReqResInfo} ReqResInfo
+@typedef {import('./types.js').ReqResMeta} ReqResMeta
 @typedef {import('./types.js').ResolvedFile} ResolvedFile
 @typedef {import('./types.js').ResolveResult} ResolveResult
 @typedef {import('./types.js').ServerOptions} ServerOptions
+@typedef {'error' | 'headers' | 'list' | 'file'} ResponseMode
 **/
 
 /**
  * @param {ServerOptions} options
- * @param {{ logNetwork?: (info: ReqResInfo) => void }} callbacks
- * @returns {import('node:http').Server}
+ * @param {{ logNetwork?: (data: ReqResMeta) => void }} [callbacks]
+ * @returns {Server}
  */
-export function staticServer(options, { logNetwork }) {
-	const resolver = new FileResolver(options, fsUtils);
+export function staticServer(options, callbacks) {
+	const resolver = new FileResolver(options, fsProxy);
+	const handlerOptions = { ...options, streaming: true };
 
 	return createServer(async (req, res) => {
-		/**
-		 * @type {Pick<ReqResInfo, 'method' | 'startedAt' | 'error'>}
-		 */
-		const logInfo = {
-			method: req.method ?? '',
-			startedAt: Date.now(),
-		};
+		const handler = new RequestHandler({ req, res }, resolver, handlerOptions);
+		res.on('close', () => {
+			handler.endedAt = Date.now();
+			callbacks?.logNetwork?.(handler.data);
+		});
+		await handler.process();
+	});
+}
 
-		const { file, ...result } = await resolver.find(req.url ?? '');
+export class RequestHandler {
+	#req;
+	#res;
+	#options;
+	#resolver;
 
-		if (logNetwork) {
-			res.on('close', () => {
-				logNetwork({
-					status: result.status,
-					urlPath: result.urlPath,
-					localPath: file?.localPath ?? null,
-					...logInfo,
-					endedAt: Date.now(),
-				});
-			});
+	/** @type {number} */
+	startedAt = Date.now();
+	/** @type {number | undefined} */
+	endedAt;
+	/** @type {string} */
+	url = '';
+	/** @type {string} */
+	urlPath = '';
+	/**
+	 * File matching the requested urlPath, if found and readable
+	 * @type {ResolvedFile | null}
+	 */
+	file = null;
+	/** @type {ResponseMode} */
+	mode = 'error';
+	/**
+	 * Error that may be logged to the terminal
+	 * @type {Error | string | undefined}
+	 */
+	error;
+
+	/**
+	 * @param {{ req: IncomingMessage, res: ServerResponse }} reqRes
+	 * @param {FileResolver} resolver
+	 * @param {ServerOptions & {streaming: boolean}} options
+	 */
+	constructor({ req, res }, resolver, options) {
+		this.#req = req;
+		this.#res = res;
+		this.#resolver = resolver;
+		this.#options = options;
+		this.status = 404;
+		if (req.url) {
+			this.url = req.url;
+			this.urlPath = req.url.split(/[\?\#]/)[0];
+		}
+	}
+
+	get method() {
+		return this.#req.method ?? '';
+	}
+	get status() {
+		return this.#res.statusCode;
+	}
+	set status(code) {
+		this.#res.statusCode = code;
+	}
+	get headers() {
+		return this.#res.getHeaders();
+	}
+
+	async process() {
+		// bail for unsupported http methods
+		if (!SUPPORTED_METHODS.includes(this.method)) {
+			this.error = new Error(`HTTP method ${this.method} is not supported`);
+			this.status = 405;
+			return this.#sendErrorPage();
 		}
 
+		// no need to look up files for the '*' OPTIONS request
+		if (this.method === 'OPTIONS' && this.url === '*') {
+			this.status = 204;
+			this.#setHeaders('*', { cors: this.#options.cors });
+			return this.#send();
+		}
+
+		const { status, urlPath, file } = await this.#resolver.find(this.url);
+		this.status = status;
+		this.urlPath = urlPath;
+		this.file = file;
+
 		// found a file to serve
-		if (
-			result.status === 200 &&
-			file?.kind === 'file' &&
-			file.filePath != null &&
-			file.localPath != null
-		) {
-			let fileHandle;
-			try {
-				// check that we can actually open the file
-				// (especially on windows where it might be busy)
-				fileHandle = await open(file.filePath);
-				const headers = fileHeaders({
-					localPath: file.localPath,
-					contentType: await getContentType({
-						filePath: file.localPath,
-						fileHandle,
-					}),
-					cors: options.cors,
-					headers: options.headers,
-				});
-				res.writeHead(result.status, headers);
-				const stream = fileHandle.createReadStream({
-					autoClose: true,
-					start: 0,
-				});
-				stream.pipe(res);
-			} catch (/** @type {any} */ err) {
-				result.status = 500;
-				if (err?.syscall === 'open') {
-					if (err.code === 'EBUSY') result.status = 403;
-					fileHandle?.close();
-				}
-				if (err?.message) {
-					logInfo.error = err;
-				}
-				await sendErrorPage(res, result, options);
-			}
+		if (status === 200 && file?.kind === 'file' && file.localPath != null) {
+			return this.#sendFile(file);
 		}
 
 		// found a directory that we can show a listing for
-		else if (
-			result.status === 200 &&
-			file?.kind === 'dir' &&
-			file.filePath != null &&
-			file.localPath != null
-		) {
-			const items = await resolver.index(file.filePath);
-			await sendDirListPage(res, { ...result, file, items }, options);
+		else if (status === 200 && file?.kind === 'dir' && file.localPath != null) {
+			return this.#sendListPage(file);
 		}
 
-		// show an error page
-		else {
-			await sendErrorPage(res, result, options);
-		}
-	});
-}
-
-/**
- * @param {import('node:http').ServerResponse} res
- * @param {{ status: number, urlPath: string; file: ResolvedFile; items: DirIndexItem[] }} data
- * @param {ServerOptions} options
- */
-async function sendDirListPage(res, { status, urlPath, file, items }, options) {
-	const headers = fileHeaders({
-		localPath: 'index.html',
-		// ignore user options for directory listings
-		cors: false,
-		headers: [],
-	});
-	const body = await dirListPage({ urlPath, file, items }, options);
-	res.writeHead(status, headers);
-	res.write(body);
-	res.end();
-}
-
-/**
- * @param {import('node:http').ServerResponse} res
- * @param {Pick<ResolveResult, 'status' | 'urlPath'>} result
- * @param {ServerOptions} options
- */
-async function sendErrorPage(res, result, options) {
-	const headers = fileHeaders({
-		localPath: 'error.html',
-		cors: options.cors,
-		// ignore custom headers for error pages
-		headers: [],
-	});
-	const body = await errorPage(result);
-	res.writeHead(result.status, headers);
-	res.write(body);
-	res.end();
-}
-
-/**
- * @param {{ localPath: string; contentType?: string; cors: boolean; headers: ServerOptions['headers'] }} data
- * @returns {Record<string, string>}
- */
-export function fileHeaders({ localPath, contentType, cors, headers }) {
-	/** @type {Record<string, string>} */
-	const obj = {};
-	const add = (key = '', value = '') => (obj[key.trim().toLowerCase()] = value);
-	add('content-type', contentType || typeForFilePath(localPath).toString());
-	if (cors) {
-		add('access-control-allow-origin', '*');
+		return this.#sendErrorPage();
 	}
-	for (const rule of headers) {
+
+	/**
+	 * @param {ResolvedFile} file
+	 */
+	async #sendFile(file) {
+		const { method } = this;
+		/** @type {FileHandle | undefined} */
+		let handle;
+		/** @type {string | undefined} */
+		let contentType;
+		/** @type {number | undefined} */
+		let contentLength;
+
+		try {
+			// check that we can actually open the file
+			// (especially on windows where it might be busy)
+			handle = await this.#resolver.open(file.filePath);
+			contentType = await getContentType({ filePath: file.filePath, fileHandle: handle });
+			contentLength = (await handle.stat()).size;
+		} catch (/** @type {any} */ err) {
+			this.status = 500;
+			if (err?.syscall === 'open') {
+				if (err.code === 'EBUSY') this.status = 403;
+				handle?.close();
+			}
+			if (err?.message) {
+				this.error = err;
+			}
+			return this.#sendErrorPage();
+		}
+
+		this.#setHeaders(file.localPath ?? file.filePath, {
+			contentType,
+			contentLength,
+			cors: this.#options.cors,
+			headers: this.#options.headers,
+		});
+
+		if (method === 'OPTIONS') {
+			handle.close();
+			this.status = 204;
+			this.#send();
+		} else if (method === 'HEAD') {
+			handle.close();
+			this.#send();
+		} else if (this.#options.streaming === false) {
+			handle.close();
+			const buffer = await this.#resolver.read(file.filePath);
+			this.#send(buffer);
+		} else {
+			const stream = handle.createReadStream({ autoClose: true, start: 0 });
+			this.#send(stream);
+		}
+	}
+
+	/**
+	 * @param {ResolvedFile} dir
+	 */
+	async #sendListPage(dir) {
+		const items = await this.#resolver.index(dir.filePath);
+		let body;
+		let contentLength;
+		if (this.method !== 'OPTIONS') {
+			body = await dirListPage({ urlPath: this.urlPath, file: dir, items }, this.#options);
+			contentLength = strBytes(body);
+		}
+		this.#setHeaders('index.html', {
+			contentLength,
+			cors: false,
+			headers: [],
+		});
+		return this.#send(body);
+	}
+
+	async #sendErrorPage() {
+		let body;
+		let contentLength;
+		if (this.method !== 'OPTIONS') {
+			body = await errorPage({ status: this.status, urlPath: this.urlPath });
+			contentLength = strBytes(body);
+		}
+		this.#setHeaders('error.html', {
+			contentLength,
+			cors: this.#options.cors,
+			headers: [],
+		});
+		this.#send(body);
+	}
+
+	/**
+	 * @param {string | import('node:buffer').Buffer | import('node:fs').ReadStream} [contents]
+	 */
+	#send(contents) {
+		if (this.method === 'HEAD' || this.method === 'OPTIONS') {
+			this.#res.end();
+		} else {
+			if (typeof contents === 'string' || Buffer.isBuffer(contents)) {
+				this.#res.write(contents);
+				this.#res.end();
+			} else if (typeof contents?.pipe === 'function') {
+				contents.pipe(this.#res);
+			}
+		}
+	}
+
+	/**
+	 * @param {string} localPath
+	 * @param {Partial<{ contentType: string, contentLength: number; cors: boolean; headers: ServerOptions['headers'] }>} options
+	 */
+	#setHeaders(localPath, { contentLength, contentType, cors, headers }) {
+		const { method, status } = this;
+		const isOptions = method === 'OPTIONS';
+
+		if (isOptions || status === 405) {
+			this.#setHeader('allow', SUPPORTED_METHODS.join(', '));
+		}
+		if (!isOptions) {
+			contentType ??= typeForFilePath(localPath).toString();
+			this.#setHeader('content-type', contentType);
+		}
+		if (isOptions || status === 204) {
+			contentLength = 0;
+		}
+		if (typeof contentLength === 'number') {
+			this.#setHeader('content-length', String(contentLength));
+		}
+
+		if (cors ?? this.#options.cors) {
+			this.#setCorsHeaders();
+		}
+
+		const headerRules = headers ?? this.#options.headers;
+		if (headerRules.length) {
+			for (const { name, value } of fileHeaders(localPath, headerRules)) {
+				this.#res.setHeader(name, value);
+			}
+		}
+	}
+
+	#setCorsHeaders() {
+		const origin = this.#req.headers['origin'];
+		if (typeof origin === 'string') {
+			this.#setHeader('access-control-allow-origin', origin);
+		}
+
+		if (isPreflight(this.#req)) {
+			this.#setHeader('access-control-allow-methods', SUPPORTED_METHODS.join(', '));
+			const allowHeaders = parseHeaderNames(this.#req.headers['access-control-request-headers']);
+			if (allowHeaders.length) {
+				this.#setHeader('access-control-allow-headers', allowHeaders.join(', '));
+			}
+			this.#setHeader('access-control-max-age', '60');
+		}
+	}
+
+	/**
+	 * @param {string} name
+	 * @param {string} value
+	 */
+	#setHeader(name, value) {
+		this.#res.setHeader(headerCase(name), value);
+	}
+
+	/** @returns {ReqResMeta} */
+	get data() {
+		const { startedAt, endedAt, status, method, url, urlPath, file, error } = this;
+		return { startedAt, endedAt, status, method, url, urlPath, file, error };
+	}
+}
+
+/**
+ * @param {string} localPath
+ * @param {ServerOptions['headers']} rules
+ */
+export function fileHeaders(localPath, rules) {
+	/** @type {Array<{name: string; value: string}>}  */
+	const headers = [];
+	for (const rule of rules) {
 		if (Array.isArray(rule.include)) {
 			const matcher = new PathMatcher(rule.include);
 			if (!matcher.test(localPath)) continue;
 		}
-		for (const [key, value] of Object.entries(rule.headers)) {
-			add(key, value);
+		for (const [name, value] of Object.entries(rule.headers)) {
+			headers.push({ name, value });
 		}
 	}
-	return obj;
+	return headers;
+}
+
+/**
+ * @param {Pick<IncomingMessage, 'method' | 'headers'>} req
+ */
+function isPreflight({ method, headers }) {
+	return (
+		method === 'OPTIONS' &&
+		typeof headers['origin'] === 'string' &&
+		typeof headers['access-control-request-method'] === 'string'
+	);
+}
+
+/**
+ * @param {string} [input]
+ * @returns {string[]}
+ */
+function parseHeaderNames(input = '') {
+	const isHeader = (h = '') => /^[A-Za-z\d-_]+$/.test(h);
+	return input
+		.split(',')
+		.map((h) => h.trim())
+		.filter(isHeader);
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -17,21 +17,14 @@
 @typedef {{
 	dirSep: '/' | '\\';
 	join(...paths: string[]): string;
-	relative(from: string, to: string): string;
 	index(dirPath: string): Promise<FSEntryBase[]>;
 	info(filePath: string): Promise<FSEntryBase & {readable: boolean}>;
 	kind(filePath: string): Promise<FSEntryKind | null>;
+	open(filePath: string): Promise<import('node:fs/promises').FileHandle>;
 	readable(filePath: string, kind?: FSEntryKind | null): Promise<boolean>;
+	readFile(filePath: string): Promise<import('node:buffer').Buffer | string>;
 	realpath(filePath: string): Promise<string | null>;
-}} FSUtils
-
-@typedef {{
-	root: string;
-	ext: string[];
-	dirFile: string[];
-	dirList: boolean,
-	exclude: string[];
-}} ResolveOptions
+}} FSProxy
 
 @typedef {{
 	include?: string[];
@@ -39,13 +32,19 @@
 }} HttpHeaderRule
 
 @typedef {{
-	host: string;
-	ports: number[];
+	root: string;
+	ext: string[];
+	dirFile: string[];
+	dirList: boolean,
+	exclude: string[];
 	cors: boolean;
 	headers: HttpHeaderRule[];
-}} HttpOptions
+}} ServerOptions
 
-@typedef {HttpOptions & ResolveOptions} ServerOptions
+@typedef {{
+	host: string;
+	ports: number[];
+}} ListenOptions
 
 @typedef {{
 	kind: FSEntryKind;
@@ -62,13 +61,11 @@
 @typedef {ResolvedFile & {isParent?: boolean; target?: ResolvedFile}} DirIndexItem
 
 @typedef {{
-	startedAt: number;
+	readonly startedAt: number;
 	endedAt?: number;
-	status: number;
-	method: string;
-	urlPath: string;
-	localPath: string | null;
+	readonly method: string;
+	readonly url: string;
 	error?: Error | string;
-}} ReqResInfo
+} & ResolveResult} ReqResMeta
 
 **/

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,12 +52,11 @@ export function fwdSlash(input = '') {
 }
 
 /**
- * @type {(input: string, options?: { start?: boolean; end?: boolean }) => string}
+ * @param {string} name
+ * @returns {string}
  */
-export function trimSlash(input = '', { start, end } = { start: true, end: true }) {
-	if (start === true) input = input.replace(/^[\/\\]/, '');
-	if (end === true) input = input.replace(/[\/\\]$/, '');
-	return input;
+export function headerCase(name) {
+	return name.replace(/((^|\b|_)[a-z])/g, (s) => s.toUpperCase());
 }
 
 /**
@@ -103,6 +102,23 @@ export function intRange(start, end, limit) {
 	)
 		.fill(undefined)
 		.map((_, i) => start + i * sign);
+}
+
+/**
+ * @param {string} input
+ * @returns {number}
+ */
+export function strBytes(input) {
+	return new TextEncoder().encode(input).byteLength;
+}
+
+/**
+ * @type {(input: string, options?: { start?: boolean; end?: boolean }) => string}
+ */
+export function trimSlash(input = '', { start, end } = { start: true, end: true }) {
+	if (start === true) input = input.replace(/^[\/\\]/, '');
+	if (end === true) input = input.replace(/[\/\\]$/, '');
+	return input;
 }
 
 export function withResolvers() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,67 @@
 			},
 			"devDependencies": {
 				"@types/node": "^20.16.5",
-				"linkedom": "^0.18.4",
+				"linkedom": "^0.18.5",
+				"memfs": "^4.12.0",
 				"prettier": "^3.3.3",
 				"typescript": "~5.6.2"
+			}
+		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.0.tgz",
+			"integrity": "sha512-zlQONA+msXPPwHWZMKFVS78ewFczIll5lXiVPwFPCZUsrOKdxc2AvxU1HoNBmMRhqDZUR9HkC3UOm+6pME6Xsg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.1",
+				"@jsonjoy.com/util": "^1.1.2",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^1.20.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.3.0.tgz",
+			"integrity": "sha512-Cebt4Vk7k1xHy87kHY7KSPLT77A7Ev7IfOblyLZhtYEhrdQ6fX4EoLq3xOQ3O/DRMEh2ok5nyC180E+ABS8Wmw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/@types/node": {
@@ -170,10 +228,20 @@
 				"entities": "^4.5.0"
 			}
 		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			}
+		},
 		"node_modules/linkedom": {
-			"version": "0.18.4",
-			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.4.tgz",
-			"integrity": "sha512-JhLErxMIEOKByMi3fURXgI1fYOzR87L1Cn0+MI9GlMckFrqFZpV1SUGox1jcKtsKN3y6JgclcQf0FzZT//BuGw==",
+			"version": "0.18.5",
+			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.5.tgz",
+			"integrity": "sha512-JGLaGGtqtu+eOhYrC1wkWYTBcpVWL4AsnwAtMtgO1Q0gI0PuPJKI0zBBE+a/1BrhOE3Uw8JI/ycByAv5cLrAuQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -182,6 +250,26 @@
 				"html-escaper": "^3.0.3",
 				"htmlparser2": "^9.1.0",
 				"uhyphen": "^0.2.0"
+			}
+		},
+		"node_modules/memfs": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.12.0.tgz",
+			"integrity": "sha512-74wDsex5tQDSClVkeK1vtxqYCAgCoXxx+K4NSHzgU/muYVYByFqa+0RnrPO9NM6naWm1+G9JmZ0p6QHhXmeYfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/json-pack": "^1.0.3",
+				"@jsonjoy.com/util": "^1.3.0",
+				"tree-dump": "^1.0.1",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			}
 		},
 		"node_modules/nth-check": {
@@ -210,6 +298,43 @@
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
+		},
+		"node_modules/thingies": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+			"integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+			"dev": true,
+			"license": "Unlicense",
+			"engines": {
+				"node": ">=10.18"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
+		"node_modules/tree-dump": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+			"integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/typescript": {
 			"version": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 	},
 	"devDependencies": {
 		"@types/node": "^20.16.5",
-		"linkedom": "^0.18.4",
+		"linkedom": "^0.18.5",
+		"memfs": "^4.12.0",
 		"prettier": "^3.3.3",
 		"typescript": "~5.6.2"
 	},

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -7,7 +7,7 @@ import { argify } from './shared.js';
 suite('CLIArgs', () => {
 	test('returns empty values', () => {
 		const args = new CLIArgs([]);
-		deepStrictEqual(args.data, {
+		deepStrictEqual(args.data(), {
 			map: [],
 			list: [],
 		});
@@ -24,11 +24,11 @@ suite('CLIArgs', () => {
 		//   'foo',
 		//   '  '
 		// ]
-		deepStrictEqual(new CLIArgs(['']).data, {
+		deepStrictEqual(new CLIArgs(['']).data(), {
 			map: [],
 			list: [''],
 		});
-		deepStrictEqual(new CLIArgs(['', ' ', '']).data, {
+		deepStrictEqual(new CLIArgs(['', ' ', '']).data(), {
 			map: [],
 			list: ['', ' ', ''],
 		});
@@ -50,7 +50,7 @@ suite('CLIArgs', () => {
 		const args = argify`-one value1 --two value2`;
 		strictEqual(args.get('-one'), 'value1');
 		strictEqual(args.get('--two'), 'value2');
-		deepStrictEqual(args.data.map, [
+		deepStrictEqual(args.data().map, [
 			['-one', 'value1'],
 			['--two', 'value2'],
 		]);
@@ -61,7 +61,7 @@ suite('CLIArgs', () => {
 		strictEqual(args.get(0), '.');
 		strictEqual(args.get(1), 'hello');
 		strictEqual(args.get(2), undefined);
-		deepStrictEqual(args.data.list, ['.', 'hello']);
+		deepStrictEqual(args.data().list, ['.', 'hello']);
 	});
 
 	test('can retrieve mapped args', () => {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -3,18 +3,20 @@ import { suite, test } from 'node:test';
 
 import { stripStyle } from '../lib/color.js';
 import { requestLogLine } from '../lib/logger.js';
+import { file } from './shared.js';
 
 suite('responseLogLine', () => {
 	/**
-	 * @param {Omit<import('../lib/types.js').ReqResInfo, 'startedAt' | 'endedAt'>} info
+	 * @param {Omit<import('../lib/types.js').ReqResMeta, 'startedAt' | 'endedAt' | 'urlPath'>} data
 	 * @param {string} expected
 	 */
-	const matchLogLine = (info, expected) => {
+	const matchLogLine = (data, expected) => {
 		const time = Date.now();
 		const line = requestLogLine({
+			...data,
+			urlPath: data.url.split(/[\?\#]/)[0],
 			startedAt: time,
 			endedAt: time,
-			...info,
 		});
 		const rawLine = stripStyle(line);
 		const pattern = /^(?:\d{2}:\d{2}:\d{2} )(.*)$/;
@@ -27,8 +29,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				urlPath: '/',
-				localPath: '',
+				url: '/',
+				file: file('', 'dir'),
 			},
 			'200 — GET /',
 		);
@@ -36,8 +38,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 404,
-				urlPath: '/favicon.ico',
-				localPath: null,
+				url: '/favicon.ico',
+				file: null,
 			},
 			`404 — GET /favicon.ico`,
 		);
@@ -45,8 +47,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 403,
-				urlPath: '/.htaccess',
-				localPath: '.htaccess',
+				url: '/.htaccess',
+				file: file('.htaccess'),
 			},
 			`403 — GET /.htaccess`,
 		);
@@ -57,8 +59,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				urlPath: '/',
-				localPath: 'index.html',
+				url: '/',
+				file: file('index.html'),
 			},
 			`200 — GET /[index.html]`,
 		);
@@ -66,8 +68,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				urlPath: '/some/page',
-				localPath: 'some\\page.htm',
+				url: '/some/page',
+				file: file('some/page.htm'),
 			},
 			`200 — GET /some/page[.htm]`,
 		);
@@ -75,17 +77,17 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				urlPath: '/other/page/',
-				localPath: 'other/page.html',
+				url: '/other/page/',
+				file: file('other/page.html'),
 			},
-			`200 — GET /other/page[.html]`,
+			`200 — GET /other/page[.html]/`,
 		);
 		matchLogLine(
 			{
 				method: 'POST',
 				status: 201,
-				urlPath: '/api/hello/',
-				localPath: 'api\\hello.json',
+				url: '/api/hello',
+				file: file('api/hello.json'),
 			},
 			`201 — POST /api/hello[.json]`,
 		);
@@ -96,8 +98,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				urlPath: '/',
-				localPath: '',
+				url: '/',
+				file: file('', 'dir'),
 			},
 			`200 — GET /`,
 		);
@@ -105,8 +107,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				urlPath: '/section1',
-				localPath: 'section1',
+				url: '/section1',
+				file: file('section1', 'dir'),
 			},
 			`200 — GET /section1`,
 		);
@@ -114,8 +116,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				urlPath: '/a/b/c/d/',
-				localPath: 'a\\b\\c\\d',
+				url: '/a/b/c/d/',
+				file: file('a\\b\\c\\d', 'dir'),
 			},
 			`200 — GET /a/b/c/d/`,
 		);
@@ -126,8 +128,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 403,
-				urlPath: '/.env',
-				localPath: '.env',
+				url: '/.env',
+				file: file('.env'),
 			},
 			`403 — GET /.env`,
 		);
@@ -135,8 +137,8 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 404,
-				urlPath: '/robots.txt',
-				localPath: 'robots.txt',
+				url: '/robots.txt',
+				file: file('robots.txt'),
 			},
 			`404 — GET /robots.txt`,
 		);

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -1,7 +1,7 @@
 import { strictEqual } from 'node:assert';
 import { suite, test } from 'node:test';
 
-import { readPkgJson } from '../lib/node-fs.js';
+import { readPkgJson } from '../lib/fs-proxy.js';
 
 suite('package.json', () => {
 	const pkgJson = readPkgJson();

--- a/test/resolver.test.js
+++ b/test/resolver.test.js
@@ -2,7 +2,7 @@ import { deepStrictEqual, strictEqual, throws } from 'node:assert';
 import { suite, test } from 'node:test';
 
 import { FileResolver, PathMatcher } from '../lib/resolver.js';
-import { defaultResolveOptions, file, getFsUtils, getResolver, root } from './shared.js';
+import { defaultOptions, file, getResolver, root, testFsProxy } from './shared.js';
 
 suite('PathMatcher', () => {
 	test('does not match strings when no patterns are provided', () => {
@@ -95,7 +95,7 @@ suite('FileResolver.#root', () => {
 			new FileResolver(
 				// @ts-expect-error
 				{},
-				getFsUtils({}),
+				testFsProxy({}),
 			);
 		}, /Missing root directory/);
 	});
@@ -250,7 +250,7 @@ suite('FileResolver.#options', () => {
 	});
 
 	test('options: exclude + include (defaults)', async () => {
-		const resolver = getResolver(defaultResolveOptions);
+		const resolver = getResolver(defaultOptions);
 		const allowed = (p = '') => resolver.allowedPath(p);
 
 		// paths that should be allowed with defaults
@@ -336,7 +336,7 @@ suite('FileResolver.find', () => {
 	});
 
 	test('default options block dotfiles', async () => {
-		const resolver = getResolver(defaultResolveOptions, find_files);
+		const resolver = getResolver(defaultOptions, find_files);
 		const find = (url = '/') =>
 			resolver.find(url).then((value) => `${value.status} ${value.file?.localPath ?? null}`);
 
@@ -355,7 +355,7 @@ suite('FileResolver.find', () => {
 	});
 
 	test('default options resolve index.html', async () => {
-		const resolver = getResolver(defaultResolveOptions, find_files);
+		const resolver = getResolver(defaultOptions, find_files);
 
 		deepStrictEqual(await resolver.find('/'), {
 			urlPath: '/',
@@ -373,7 +373,7 @@ suite('FileResolver.find', () => {
 	});
 
 	test('default options resolve .html extension', async () => {
-		const resolver = getResolver(defaultResolveOptions, find_files);
+		const resolver = getResolver(defaultOptions, find_files);
 
 		// adds .html
 		for (const fileLike of ['index', 'page1', 'section/index']) {
@@ -411,14 +411,14 @@ suite('FileResolver.index', () => {
 	};
 
 	test('does not index directories when options.dirList is false', async () => {
-		const resolver = getResolver({ ...defaultResolveOptions, dirList: false }, index_files);
+		const resolver = getResolver({ ...defaultOptions, dirList: false }, index_files);
 		deepStrictEqual(await resolver.index(root()), []);
 		deepStrictEqual(await resolver.index(root`section`), []);
 		deepStrictEqual(await resolver.index(root`doesnt-exist`), []);
 	});
 
 	test('indexes directories when options.dirList is true', async () => {
-		const resolver = getResolver({ ...defaultResolveOptions }, index_files);
+		const resolver = getResolver({ ...defaultOptions }, index_files);
 		deepStrictEqual(await resolver.index(root()), [
 			file('.well-known', 'dir'),
 			file('about-us.html'),

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,98 +1,387 @@
-import { deepStrictEqual } from 'node:assert';
+import { deepStrictEqual, doesNotThrow, match, ok, strictEqual } from 'node:assert';
+import { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { Duplex } from 'node:stream';
 import { suite, test } from 'node:test';
 
-import { fileHeaders } from '../lib/server.js';
+import { readPkgFile } from '../lib/fs-proxy.js';
+import { fileHeaders, staticServer, RequestHandler } from '../lib/server.js';
+import { blankOptions, defaultOptions, file, getResolver } from './shared.js';
 
 /**
 @typedef {import('../lib/types.js').HttpHeaderRule} HttpHeaderRule
 @typedef {import('../lib/types.js').ServerOptions} ServerOptions
-@typedef {Parameters<typeof fileHeaders>[0]} FileHeadersData
+@typedef {Record<string, undefined | number | string | string[]>} ResponseHeaders
 **/
 
-suite('fileHeaders', () => {
-	/**
-	 * @param {Partial<FileHeadersData> & { localPath: string }} data
-	 * @param {Record<string, string>} expected
-	 */
-	const checkHeaders = (data, expected) => {
-		deepStrictEqual(fileHeaders({ cors: false, headers: [], ...data }), expected);
+const allowMethods = 'GET, HEAD, OPTIONS, POST';
+
+/**
+ * @param {ResponseHeaders} actual
+ * @param {ResponseHeaders} expected */
+function checkHeaders(actual, expected) {
+	deepStrictEqual(actual, headersObj(expected));
+}
+
+/**
+ * @param {ResponseHeaders} data
+ */
+function headersObj(data) {
+	/** @type {ResponseHeaders} */
+	const result = Object.create(null);
+	for (const [key, value] of Object.entries(data)) {
+		result[key.toLowerCase()] = value;
+	}
+	return result;
+}
+
+/**
+ * @param {string} method
+ * @param {string} url
+ * @param {Record<string, string | string[]>} [headers]
+ */
+function mockReqRes(method, url, headers = {}) {
+	const req = new IncomingMessage(
+		// @ts-expect-error (we don't have a socket, hoping this is enough for testing)
+		new Duplex(),
+	);
+	req.method = method;
+	req.url = url;
+	for (const [name, value] of Object.entries(headers)) {
+		req.headers[name.toLowerCase()] = value;
+	}
+	const res = new ServerResponse(req);
+	return { req, res };
+}
+
+/**
+ * @param {ServerOptions} options
+ * @param {Parameters<typeof getResolver>[1]} files
+ * @returns {(method: string, url: string, headers?: Record<string, string | string[]>) => RequestHandler}
+ */
+function withHandlerContext(options, files) {
+	const resolver = getResolver(options, files);
+	const handlerOptions = { ...options, streaming: false };
+
+	return (method, url, headers) => {
+		const { req, res } = mockReqRes(method, url, headers);
+		return new RequestHandler({ req, res }, resolver, handlerOptions);
 	};
+}
 
-	test('keeps provided content-type header', () => {
-		checkHeaders(
-			{ localPath: 'foo', contentType: 'text/html' },
-			{
-				'content-type': 'text/html',
-			},
-		);
-	});
+/**
+ * @param {HttpHeaderRule[]} rules
+ * @returns {(filePath: string) => Array<{name: string; value: string}>}
+ */
+function withHeaderRules(rules) {
+	return (filePath) => fileHeaders(filePath, rules);
+}
 
-	test('sets content-type header', () => {
-		checkHeaders(
-			{ localPath: 'foo' },
-			{
-				'content-type': 'application/octet-stream',
-			},
-		);
-		checkHeaders(
-			{ localPath: 'hello.html' },
-			{
-				'content-type': 'text/html; charset=UTF-8',
-			},
-		);
-	});
-
-	test('cors option sets access-control-allow-origin', () => {
-		checkHeaders(
-			{ localPath: 'foo', cors: false },
-			{
-				'content-type': 'application/octet-stream',
-			},
-		);
-		checkHeaders(
-			{ localPath: 'foo', cors: true },
-			{
-				'content-type': 'application/octet-stream',
-				'access-control-allow-origin': '*',
-			},
-		);
-	});
-
+suite('fileHeaders', () => {
 	test('headers without include patterns are added for all responses', () => {
-		/** @type {FileHeadersData['headers']} */
-		const headers = [
+		const headers = withHeaderRules([
 			{ headers: { 'X-Header1': 'one' } },
 			{ headers: { 'X-Header2': 'two' } },
 			{ headers: { 'x-header1': 'three' } },
+			{ headers: { 'X-Header2': 'four' } },
+		]);
+		const expected = [
+			{ name: 'X-Header1', value: 'one' },
+			{ name: 'X-Header2', value: 'two' },
+			{ name: 'x-header1', value: 'three' },
+			{ name: 'X-Header2', value: 'four' },
 		];
-		checkHeaders(
-			{ localPath: 'some/file.txt', headers },
-			{
-				'content-type': 'text/plain; charset=UTF-8',
-				'x-header1': 'three',
-				'x-header2': 'two',
-			},
-		);
+		deepStrictEqual(headers(''), expected);
+		deepStrictEqual(headers('file.ext'), expected);
+		deepStrictEqual(headers('any/thing.ext'), expected);
 	});
 
 	test('custom headers with pattern are added matching files only', () => {
-		/** @type {FileHeadersData['headers']} */
-		const headers = [
+		const headers = withHeaderRules([
 			{ include: ['path'], headers: { 'x-header1': 'true' } },
 			{ include: ['*.test'], headers: { 'Content-Type': 'test/custom-type' } },
+		]);
+		deepStrictEqual(headers(''), []);
+		deepStrictEqual(headers('wrong-path/file.test.txt'), []);
+		deepStrictEqual(headers('path/to/README.md'), [{ name: 'x-header1', value: 'true' }]);
+		deepStrictEqual(headers('README.test'), [{ name: 'Content-Type', value: 'test/custom-type' }]);
+		deepStrictEqual(headers('other/path/cool.test/index.html'), [
+			{ name: 'x-header1', value: 'true' },
+			{ name: 'Content-Type', value: 'test/custom-type' },
+		]);
+	});
+});
+
+suite('staticServer', () => {
+	test("it doesn't crash", () => {
+		doesNotThrow(() => {
+			staticServer(defaultOptions);
+		});
+	});
+	test('returns a Node.js http.Server', () => {
+		const server = staticServer(defaultOptions);
+		ok(server instanceof Server);
+		strictEqual(typeof server.listen, 'function');
+	});
+});
+
+suite('RequestHandler.constructor', () => {
+	test('starts with a 404 status', async () => {
+		const options = { ...blankOptions, streaming: false };
+		const handler = new RequestHandler(mockReqRes('GET', '/'), getResolver(), options);
+		strictEqual(handler.method, 'GET');
+		strictEqual(handler.urlPath, '/');
+		strictEqual(handler.status, 404);
+		strictEqual(handler.file, null);
+	});
+});
+
+suite('RequestHandler.process', async () => {
+	const test_files = {
+		'.gitignore': '*.html\n',
+		'index.html': '<h1>Hello World</h1>',
+		'manifest.json': '{"hello": "world"}',
+		'README.md': '# Cool stuff\n',
+		'section/.htaccess': '# secret',
+		'section/favicon.svg': await readPkgFile('lib/assets/favicon-list.svg'),
+		'section/index.html': '<h1>Section</h1>',
+		'section/other-page.html': '<h1>Other page</h1>',
+		'section/page.html': '<h1>Cool page</h1>',
+		'.well-known/security.txt': '# hello',
+		'.well-known/something-else.json': '{"data":{}}',
+	};
+
+	const request0 = withHandlerContext(blankOptions, test_files);
+	const request = withHandlerContext(defaultOptions, test_files);
+
+	for (const method of ['PUT', 'DELETE']) {
+		test(`${method} method is unsupported`, async () => {
+			const handler = request(method, '/README.md');
+			strictEqual(handler.method, method);
+			strictEqual(handler.status, 404);
+			strictEqual(handler.urlPath, '/README.md');
+			strictEqual(handler.file, null);
+
+			await handler.process();
+			strictEqual(handler.status, 405);
+			strictEqual(handler.headers['allow'], allowMethods);
+			strictEqual(handler.headers['content-type'], 'text/html; charset=UTF-8');
+			match(`${handler.headers['content-length']}`, /^\d+$/);
+		});
+	}
+
+	test('GET resolves a request with an index file', async () => {
+		const handler = request('GET', '/');
+
+		// Initial status is 404
+		strictEqual(handler.method, 'GET');
+		strictEqual(handler.status, 404);
+		strictEqual(typeof handler.startedAt, 'number');
+
+		// Processing the request finds the index.html file
+		await handler.process();
+		strictEqual(handler.status, 200);
+		strictEqual(handler.file?.kind, 'file');
+		strictEqual(handler.file?.localPath, 'index.html');
+		strictEqual(handler.error, undefined);
+	});
+
+	test('GET returns a directory listing', async () => {
+		const dir_list_files = {
+			'some-folder/package.json': '{}',
+			'some-folder/README.md': '# Hello',
+		};
+		const parent = file('', 'dir');
+		const folder = file('some-folder', 'dir');
+		const cases = [
+			{ dirList: false, url: '/', status: 404, file: parent },
+			{ dirList: false, url: '/some-folder/', status: 404, file: folder },
+			{ dirList: true, url: '/', status: 200, file: parent },
+			{ dirList: true, url: '/some-folder', status: 200, file: folder },
 		];
-		checkHeaders(
-			{ localPath: 'README.test', headers },
-			{
-				'content-type': 'test/custom-type',
-			},
-		);
-		checkHeaders(
-			{ localPath: 'path/to/README.md', headers },
-			{
-				'content-type': 'text/markdown; charset=UTF-8',
-				'x-header1': 'true',
-			},
-		);
+		for (const { dirList, url, status, file } of cases) {
+			const request = withHandlerContext({ ...blankOptions, dirList }, dir_list_files);
+			const handler = request('GET', url);
+			await handler.process();
+			strictEqual(handler.status, status);
+			// folder is still resolved when status is 404, just not used
+			deepStrictEqual(handler.file, file);
+			// both error and list pages are HTML
+			strictEqual(handler.headers['content-type'], 'text/html; charset=UTF-8');
+		}
+	});
+
+	test('GET returns a 404 for an unknown path', async () => {
+		const control = request('GET', '/index.html');
+		const noFile = request('GET', '/does/not/exist');
+		await Promise.all([control.process(), noFile.process()]);
+		strictEqual(control.status, 200);
+		strictEqual(control.file?.localPath, 'index.html');
+		strictEqual(noFile.status, 404);
+		strictEqual(noFile.file, null);
+	});
+
+	test('GET finds .html files without extension', async () => {
+		const page1 = request('GET', '/section/page');
+		const page2 = request('GET', '/section/other-page');
+
+		await Promise.all([page1.process(), page2.process()]);
+		strictEqual(page1.status, 200);
+		strictEqual(page1.file?.localPath, 'section/page.html');
+		strictEqual(page2.status, 200);
+		strictEqual(page2.file?.localPath, 'section/other-page.html');
+	});
+
+	test('GET shows correct content-type', async () => {
+		const cases = [
+			{ url: '/manifest.json', contentType: 'application/json; charset=UTF-8' },
+			{ url: '/README.md', contentType: 'text/markdown; charset=UTF-8' },
+			{ url: '/section/favicon.svg', contentType: 'image/svg+xml; charset=UTF-8' },
+			{ url: '/section/page', contentType: 'text/html; charset=UTF-8' },
+		];
+
+		for (const { url, contentType } of cases) {
+			const handler = request('GET', url);
+			await handler.process();
+			strictEqual(handler.status, 200);
+			strictEqual(handler.headers['content-type'], contentType);
+		}
+	});
+
+	test('POST is handled as GET', async () => {
+		const cases = [
+			{ url: '/', localPath: 'index.html', status: 200 },
+			{ url: '/manifest.json', localPath: 'manifest.json', status: 200 },
+			{ url: '/doesnt/exist', localPath: undefined, status: 404 },
+		];
+		for (const { url, localPath, status } of cases) {
+			const getReq = request('GET', url);
+			await getReq.process();
+			strictEqual(getReq.method, 'GET');
+			strictEqual(getReq.status, status);
+			strictEqual(getReq.file?.localPath, localPath);
+
+			const postReq = request('POST', url);
+			await postReq.process();
+			strictEqual(postReq.method, 'POST');
+			strictEqual(postReq.status, status);
+			strictEqual(postReq.file?.localPath, localPath);
+
+			deepStrictEqual(getReq.file, postReq.file);
+		}
+	});
+
+	test('HEAD with a 200 response', async () => {
+		const handler = request('HEAD', '/');
+		await handler.process();
+		strictEqual(handler.method, 'HEAD');
+		strictEqual(handler.status, 200);
+		strictEqual(handler.file?.localPath, 'index.html');
+		strictEqual(handler.headers['content-type'], 'text/html; charset=UTF-8');
+		match(`${handler.headers['content-length']}`, /^\d+$/);
+	});
+
+	test('HEAD with a 404 response', async () => {
+		const handler = request('HEAD', '/doesnt/exist');
+		await handler.process();
+		strictEqual(handler.method, 'HEAD');
+		strictEqual(handler.status, 404);
+		strictEqual(handler.file, null);
+		strictEqual(handler.headers['content-type'], 'text/html; charset=UTF-8');
+		match(`${handler.headers['content-length']}`, /^\d+$/);
+	});
+
+	test('OPTIONS *', async () => {
+		const handler = request('OPTIONS', '*');
+		await handler.process();
+		strictEqual(handler.method, 'OPTIONS');
+		strictEqual(handler.status, 204);
+		checkHeaders(handler.headers, {
+			allow: allowMethods,
+			'content-length': '0',
+		});
+	});
+
+	test('OPTIONS for existing file', async () => {
+		const handler = request('OPTIONS', '/section/page');
+		await handler.process();
+		strictEqual(handler.method, 'OPTIONS');
+		strictEqual(handler.status, 204);
+		checkHeaders(handler.headers, {
+			allow: allowMethods,
+			'content-length': '0',
+		});
+	});
+
+	test('OPTIONS for missing file', async () => {
+		const handler = request('OPTIONS', '/doesnt/exist');
+		await handler.process();
+		strictEqual(handler.status, 404);
+		checkHeaders(handler.headers, {
+			allow: allowMethods,
+			'content-length': '0',
+		});
+	});
+
+	test('CORS: no CORS headers by default', async () => {
+		const request = withHandlerContext(blankOptions, test_files);
+
+		const getReq = request('GET', '/manifest.json', {
+			Origin: 'https://example.com',
+			'Access-Control-Request-Method': 'GET',
+		});
+		const preflightReq = request('OPTIONS', '/manifest.json', {
+			Origin: 'https://example.com',
+			'Access-Control-Request-Method': 'POST',
+			'Access-Control-Request-Headers': 'X-Header1',
+		});
+
+		await getReq.process();
+		await preflightReq.process();
+
+		strictEqual(getReq.status, 200);
+		checkHeaders(getReq.headers, {
+			'content-type': 'application/json; charset=UTF-8',
+			'content-length': '18',
+		});
+
+		strictEqual(preflightReq.status, 204);
+		checkHeaders(preflightReq.headers, {
+			allow: allowMethods,
+			'content-length': '0',
+		});
+	});
+
+	test('CORS headers when enabled', async () => {
+		const request = withHandlerContext({ ...blankOptions, cors: true }, test_files);
+
+		const getReq = request('GET', '/manifest.json', {
+			Origin: 'https://example.com',
+			'Access-Control-Request-Method': 'GET',
+		});
+		const preflightReq = request('OPTIONS', '/manifest.json', {
+			Origin: 'https://example.com',
+			'Access-Control-Request-Method': 'POST',
+			'Access-Control-Request-Headers': 'X-Header1',
+		});
+
+		await getReq.process();
+		await preflightReq.process();
+
+		strictEqual(getReq.status, 200);
+		checkHeaders(getReq.headers, {
+			'access-control-allow-origin': 'https://example.com',
+			'content-type': 'application/json; charset=UTF-8',
+			'content-length': '18',
+		});
+
+		strictEqual(preflightReq.status, 204);
+		checkHeaders(preflightReq.headers, {
+			allow: allowMethods,
+			'access-control-allow-headers': 'X-Header1',
+			'access-control-allow-methods': 'GET, HEAD, OPTIONS, POST',
+			'access-control-allow-origin': 'https://example.com',
+			'access-control-max-age': '60',
+			'content-length': '0',
+		});
 	});
 });

--- a/test/shared.js
+++ b/test/shared.js
@@ -1,26 +1,42 @@
+import { Buffer } from 'node:buffer';
 import posixPath from 'node:path/posix';
+import { memfs } from 'memfs';
 
 import { CLIArgs } from '../lib/args.js';
 import { DIR_FILE_DEFAULT, EXTENSIONS_DEFAULT, FILE_EXCLUDE_DEFAULT } from '../lib/constants.js';
+import { statsKind } from '../lib/fs-proxy.js';
 import { FileResolver } from '../lib/resolver.js';
 import { trimSlash } from '../lib/utils.js';
 
 /**
 @typedef {import('../lib/types.js').DirIndexItem} DirIndexItem
 @typedef {import('../lib/types.js').FSEntryKind} FSEntryKind
-@typedef {import('../lib/types.js').FSUtils} FSUtils
+@typedef {import('../lib/types.js').FSProxy} FSProxy
 @typedef {import('../lib/types.js').ResolvedFile} ResolvedFile
-@typedef {import('../lib/types.js').ResolveOptions} ResolveOptions
+@typedef {import('../lib/types.js').ServerOptions} ServerOptions
 @typedef {{path: string; kind: FSEntryKind, readable: boolean; link?: string}} VFile
 **/
 
-/** @type {ResolveOptions} */
-export const defaultResolveOptions = {
+/** @type {ServerOptions} */
+export const blankOptions = {
+	root: root(),
+	dirFile: [],
+	dirList: false,
+	ext: [],
+	exclude: [],
+	cors: false,
+	headers: [],
+};
+
+/** @type {ServerOptions} */
+export const defaultOptions = {
 	root: root(),
 	dirFile: [...DIR_FILE_DEFAULT],
 	dirList: true,
 	ext: [...EXTENSIONS_DEFAULT],
 	exclude: [...FILE_EXCLUDE_DEFAULT],
+	cors: false,
+	headers: [],
 };
 
 /**
@@ -61,108 +77,8 @@ export function argify(strings = '', ...values) {
 	);
 }
 
-class TestFS {
-	/** @type {Map<string, VFile>} */
-	files = new Map();
-
-	/**
-	 * @param {Record<string, boolean | string>} filePaths
-	 */
-	constructor(filePaths) {
-		// add root dir
-		this.files.set(root(), { path: root(), kind: 'dir', readable: true });
-
-		// add dirs and files
-		for (const [key, value] of Object.entries(filePaths)) {
-			const relPath = trimSlash(key);
-
-			/** @type {string[]} */
-			const paths = [];
-			for (const segment of relPath.split('/')) {
-				const prev = paths.at(-1);
-				paths.push(prev ? `${prev}/${segment}` : segment);
-			}
-
-			for (const path of paths) {
-				const isDir = relPath.startsWith(`${path}/`);
-				const fullPath = root(path);
-				if (this.has(fullPath)) continue;
-				this.set(fullPath, {
-					path: fullPath,
-					kind: isDir ? 'dir' : 'file',
-					readable: isDir ? true : value !== false,
-					link: typeof value === 'string' ? value : undefined,
-				});
-			}
-		}
-	}
-
-	#trimPath(filePath = '') {
-		return trimSlash(filePath, { end: true });
-	}
-
-	has(filePath = '') {
-		return this.files.has(this.#trimPath(filePath));
-	}
-
-	get(filePath = '') {
-		return this.files.get(this.#trimPath(filePath));
-	}
-
-	/**
-	 * @param {string} filePath
-	 * @param {VFile} vfile
-	 */
-	set(filePath = '', vfile) {
-		return this.files.set(this.#trimPath(filePath), vfile);
-	}
-}
-
 /**
- * @type {(filePaths: Record<string, boolean | string>) => FSUtils}
- */
-export function getFsUtils(filePaths) {
-	const vfs = new TestFS(filePaths);
-	return {
-		dirSep: posixPath.sep,
-		join: posixPath.join,
-		relative: posixPath.relative,
-		async index(dirPath) {
-			if (!vfs.has(dirPath) || vfs.get(dirPath)?.kind !== 'dir') return [];
-			const prefix = `${dirPath}/`;
-			const entries = [];
-			for (const entry of vfs.files.values()) {
-				if (!entry.path.startsWith(prefix)) continue;
-				const relative = entry.path.slice(prefix.length);
-				if (!relative.includes('/')) {
-					entries.push({ filePath: entry.path, kind: entry.kind });
-				}
-			}
-			return entries;
-		},
-		async info(filePath) {
-			const kind = await this.kind(filePath);
-			const readable = await this.readable(filePath);
-			return { filePath, kind, readable };
-		},
-		async kind(filePath) {
-			return vfs.get(filePath)?.kind ?? null;
-		},
-		async readable(filePath) {
-			return vfs.get(filePath)?.readable ?? false;
-		},
-		async realpath(filePath) {
-			const file = vfs.get(filePath);
-			if (file?.kind === 'link') {
-				return file.link && vfs.has(file.link) ? file.link : null;
-			}
-			return file ? filePath : null;
-		},
-	};
-}
-
-/**
- * @type {(options?: Partial<ResolveOptions>, files?: Record<string, boolean | string>) => FileResolver}
+ * @type {(options?: Partial<ServerOptions>, files?: Record<string, boolean | string | Buffer>) => FileResolver}
  */
 export function getResolver(options = {}, files = {}) {
 	return new FileResolver(
@@ -170,6 +86,88 @@ export function getResolver(options = {}, files = {}) {
 			root: options.root ?? root(),
 			...options,
 		},
-		getFsUtils(files),
+		testFsProxy(files),
 	);
+}
+
+/**
+ * @param {Record<string, boolean | string | Buffer>} [filePaths]
+ * @returns {import('../lib/types.js').FSProxy}
+ */
+export function testFsProxy(filePaths = {}) {
+	const cwd = root();
+	const { fs } = memfs({}, cwd);
+	const { lstat, open, readdir, readFile, realpath } = fs.promises;
+	const b64UrlPrefix = /^data\:(\w+\/[\w\-\+\_]+)?\;base64,/;
+
+	for (let [key, value] of Object.entries(filePaths)) {
+		const path = key.startsWith(cwd) ? key : root(key);
+		const dir = posixPath.dirname(path);
+		if (!fs.existsSync(dir)) {
+			fs.mkdirSync(dir, { recursive: true });
+		}
+		let contents = typeof value === 'boolean' ? '' : value;
+		if (typeof contents === 'string' && b64UrlPrefix.test(contents)) {
+			contents = Buffer.from(contents.replace(b64UrlPrefix, ''), 'base64url');
+		}
+		fs.writeFileSync(path, contents);
+		if (value === false) {
+			fs.chmodSync(path, 0o000);
+		}
+	}
+
+	return {
+		dirSep: posixPath.sep,
+		join: posixPath.join,
+		async index(dirPath) {
+			try {
+				/** @type {any[]} */
+				const entries = await readdir(dirPath, { withFileTypes: true });
+				return entries.map((entry) => ({
+					filePath: this.join(entry.parentPath, entry.name),
+					kind: statsKind(entry),
+				}));
+			} catch {
+				return [];
+			}
+		},
+		async info(filePath) {
+			const kind = await this.kind(filePath);
+			const readable = await this.readable(filePath);
+			return { filePath, kind, readable };
+		},
+		async kind(filePath) {
+			try {
+				const stats = await lstat(filePath);
+				if (stats.isSymbolicLink()) return 'link';
+				if (stats.isDirectory()) return 'dir';
+				else if (stats.isFile()) return 'file';
+				return null;
+			} catch (err) {
+				return null;
+			}
+		},
+		// @ts-expect-error (memfs open doesn't have FileHandle#createReadStream)
+		async open(filePath) {
+			return open(filePath);
+		},
+		async readFile(filePath) {
+			return readFile(filePath);
+		},
+		async readable(filePath, kind) {
+			if (kind === undefined) {
+				kind = await this.kind(filePath);
+			}
+			if (kind === 'dir' || kind === 'file') {
+				const expected = kind === 'dir' ? ['7'] : ['7', '6', '4'];
+				const user = (await lstat(filePath)).mode.toString(8).at(-3);
+				return Boolean(user && expected.includes(user));
+			}
+			return false;
+		},
+		async realpath(filePath) {
+			const real = await realpath(filePath);
+			return typeof real === 'string' ? real : null;
+		},
+	};
 }


### PR DESCRIPTION
Fixes #12 (if my understanding of CORS is correct, which it might not be).

- Rejects requests for unsupported HTTP methods.
- Handles `HEAD` requests.
- Send `Allow` response header for `OPTIONS` requests.
- Send `Access-Control-Allow-…` headers for CORS pre-flight requests, provided that the `--cors` option is enabled.

Code-wise, it's a pretty big change. I found a way to test server responses with virtual files using `memfs` and by moving all the logic and state management involved in building a response into its own class (`RequestHandler`), so there's a bunch of refactoring and new tests.
