### PR TITLE
fix: implement custom styleText fn for Node 18 compat

### DIFF
--- a/lib/color.js
+++ b/lib/color.js
@@ -1,6 +1,6 @@
 import { release } from 'node:os';
 import { env, platform } from 'node:process';
-import * as util from 'node:util';
+import { inspect } from 'node:util';
 
 export class ColorUtils {
 	/**
@@ -36,7 +36,8 @@ export class ColorUtils {
 	 * @type {(text: string, format?: string) => string}
 	 */
 	style = (text, format = '') => {
-		return this.#enabled ? styleText(text, format) : text;
+		if (!this.enabled) return text;
+		return styleText(format.trim().split(/\s+/g), text);
 	};
 
 	/**
@@ -50,7 +51,7 @@ export class ColorUtils {
 	 * @type {(parts: string[], format?: string) => string}
 	 */
 	sequence = (parts, format = '') => {
-		if (!format || !this.#enabled) {
+		if (!format || !this.enabled) {
 			return parts.join('');
 		}
 		const formats = format.split(',');
@@ -93,18 +94,21 @@ function checkColorSupport() {
 }
 
 /**
+ * Basic implementation of 'node:util' styleText to support Node 18 + Deno.
+ * @param {string | string[]} format
  * @param {string} text
- * @param {string} [format]
  * @returns {string}
  */
-function styleText(text, format = '') {
-	format = format.trim();
-	if (typeof util.styleText === 'function' && format != '') {
-		/** @type {any} */
-		const stFormat = format.includes(' ') ? format.split(' ') : format;
-		return util.styleText(stFormat, text);
+function styleText(format, text) {
+	let before = '';
+	let after = '';
+	for (const style of Array.isArray(format) ? format : [format]) {
+		const codes = inspect.colors[style.trim()];
+		if (!codes) continue;
+		before = `${before}\x1b[${codes[0]}m`;
+		after = `\x1b[${codes[1]}m${after}`;
 	}
-	return text;
+	return `${before}${text}${after}`;
 }
 
 /**
@@ -112,8 +116,8 @@ function styleText(text, format = '') {
  * @returns {string}
  */
 export function stripStyle(input) {
-	if (typeof input === 'string' && input.includes('\x1B[')) {
-		return input.replace(/\x1B\[[0-9]+m/g, '');
+	if (typeof input === 'string' && input.includes('\x1b[')) {
+		return input.replace(/\x1b\[\d+m/g, '');
 	}
 	return input;
 }


### PR DESCRIPTION
Turns out the basic functionality of Node's `util.styleText` is not hard to implement, so we can just write our own.

Also works around [this Deno issue](https://github.com/denoland/deno/issues/26184).
