### PR TITLE
fix(deno): handle.stat not available

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { createReadStream } from 'node:fs';
-import { open } from 'node:fs/promises';
+import { open, stat } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { createGzip, gzipSync } from 'node:zlib';
 
@@ -151,7 +151,7 @@ export class RequestHandler {
 			// check that we can actually open the file
 			// (especially on windows where it might be busy)
 			handle = await open(file.filePath);
-			statSize = (await handle.stat()).size;
+			statSize = (await stat(file.filePath)).size;
 			contentType = await getContentType({ path: file.filePath, handle });
 		} catch (/** @type {any} */ err) {
 			this.status = err?.code === 'EBUSY' ? 403 : 500;


### PR DESCRIPTION
For some reason calling `FileHandle.stat` worked in Deno in 0.4.0, but stopped working with the latest code changes on the `main` branch. No idea why. The code that fails looks identical.

This works around the problem altogether.