### PR TITLE
refactor: minimize shared types

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -177,7 +177,7 @@ which could look bad on low resolution screens
 	display: block;
 }
 
-.files-item--parent .files-name {
+.files-link[aria-label*='parent' i] .files-name {
 	letter-spacing: 0.15ch;
 }
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -2,7 +2,6 @@ import { CLI_OPTIONS, PORTS_CONFIG } from './constants.js';
 import { intRange } from './utils.js';
 
 /**
-@typedef {import('./types.d.ts').ErrorList} ErrorList
 @typedef {import('./types.d.ts').HttpHeaderRule} HttpHeaderRule
 @typedef {import('./types.d.ts').OptionSpec} OptionSpec
 @typedef {import('./types.d.ts').ServerOptions} ServerOptions
@@ -116,12 +115,12 @@ function normalizeExt(value = '') {
 	return value;
 }
 
-/** @type {(args: CLIArgs, context?: { error: ErrorList }) => Partial<ServerOptions>} */
-export function parseArgs(args, context) {
+/** @type {(args: CLIArgs, context: { onError(msg: string): void }) => Partial<ServerOptions>} */
+export function parseArgs(args, { onError }) {
 	const invalid = (optName = '', input = '') => {
 		const value =
 			typeof input === 'string' ? `'${input.replaceAll(`'`, `\'`)}'` : JSON.stringify(input);
-		context?.error(`invalid ${optName} value: ${value}`);
+		onError(`invalid ${optName} value: ${value}`);
 	};
 
 	/** @type {(spec: OptionSpec) => string | undefined} */
@@ -186,7 +185,7 @@ export function parseArgs(args, context) {
 	}
 
 	for (const name of unknownArgs(args)) {
-		context?.error(`unknown option '${name}'`);
+		onError(`unknown option '${name}'`);
 	}
 
 	// remove undefined values

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,3 +1,4 @@
+import { createServer } from 'node:http';
 import { homedir, networkInterfaces } from 'node:os';
 import { sep as dirSep } from 'node:path';
 import process, { argv, exit, platform, stdin } from 'node:process';
@@ -6,9 +7,10 @@ import { emitKeypressEvents } from 'node:readline';
 import { CLIArgs, parseArgs } from './args.js';
 import { CLI_OPTIONS, HOSTS_LOCAL, HOSTS_WILDCARD } from './constants.js';
 import { checkDirAccess, pkgFilePath, readPkgJson } from './fs-utils.js';
+import { RequestHandler } from './handler.js';
 import { color, logger, requestLogLine } from './logger.js';
 import { serverOptions } from './options.js';
-import { staticServer } from './server.js';
+import { FileResolver } from './resolver.js';
 import { clamp, errorList, getRuntime, isPrivateIPv4 } from './utils.js';
 
 /**
@@ -33,19 +35,19 @@ export async function run() {
 		return;
 	}
 
-	const error = errorList();
-	const userOptions = parseArgs(args, { error });
-	const options = serverOptions({ root: '', ...userOptions }, { error });
+	const onError = errorList();
+	const userOptions = parseArgs(args, { onError });
+	const options = serverOptions({ root: '', ...userOptions }, { onError });
 
-	await checkDirAccess(options.root, { error });
+	await checkDirAccess(options.root, { onError });
 	// check access to assets needed by server pages,
 	// to trigger a permission prompt before the server starts
 	if (getRuntime() === 'deno') {
-		await checkDirAccess(pkgFilePath('assets'));
+		await checkDirAccess(pkgFilePath('assets'), { onError: () => {} });
 	}
 
-	if (error.list.length) {
-		logger.error(...error.list);
+	if (onError.list.length) {
+		logger.error(...onError.list);
 		logger.error(`Try 'servitsy --help' for more information.`);
 		process.exitCode = 1;
 		return;
@@ -71,6 +73,9 @@ export class CLIServer {
 	/** @type {import('node:http').Server} */
 	#server;
 
+	/** @type {FileResolver} */
+	#resolver;
+
 	/** @param {ServerOptions} options */
 	constructor(options) {
 		this.#options = options;
@@ -79,16 +84,22 @@ export class CLIServer {
 			.flat()
 			.find((c) => c?.family === 'IPv4' && isPrivateIPv4(c?.address));
 
-		this.#server = staticServer(options, {
-			logNetwork: (info) => {
-				logger.write('request', requestLogLine(info));
-			},
+		const resolver = new FileResolver(options);
+		const server = createServer(async (req, res) => {
+			const handler = new RequestHandler({ req, res, resolver, options });
+			res.on('close', () => {
+				logger.write('request', requestLogLine(handler.data()));
+			});
+			await handler.process();
 		});
-		this.#server.on('error', (error) => this.#onServerError(error));
-		this.#server.on('listening', () => {
+		server.on('error', (error) => this.#onServerError(error));
+		server.on('listening', () => {
 			const info = this.headerInfo();
 			if (info) logger.write('header', info, { top: 1, bottom: 1 });
 		});
+
+		this.#resolver = resolver;
+		this.#server = server;
 	}
 
 	start() {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,10 +1,11 @@
 /** @type {string[]} */
 export const HOSTS_LOCAL = ['localhost', '127.0.0.1', '::1'];
 
-/** @type {{ v4: string; v6: string }} */
-export const HOSTS_WILDCARD = { v4: '0.0.0.0', v6: '::' };
+export const HOSTS_WILDCARD = {
+	v4: '0.0.0.0',
+	v6: '::',
+};
 
-/** @type {import('./types.d.ts').PortsConfig} */
 export const PORTS_CONFIG = {
 	initial: 8080,
 	count: 10,
@@ -29,7 +30,10 @@ export const DEFAULT_OPTIONS = {
 	exclude: ['.*', '!.well-known'],
 };
 
-/** @type {import('./types.d.ts').OptionSpecs} */
+/**
+@typedef {'cors' | 'dirFile' | 'dirList' | 'exclude' | 'ext' | 'gzip' | 'header' | 'help' | 'host' | 'port' | 'version'} OptionName
+@type {Record<OptionName, import('./types.d.ts').OptionSpec>}
+*/
 export const CLI_OPTIONS = {
 	cors: {
 		help: 'Send CORS HTTP headers in responses',

--- a/lib/content-type.js
+++ b/lib/content-type.js
@@ -2,7 +2,6 @@ import { basename, extname } from 'node:path';
 
 /**
 @typedef {import('node:fs/promises').FileHandle} FileHandle
-
 @typedef {{
 	default: string;
 	file: string[];

--- a/lib/fs-utils.js
+++ b/lib/fs-utils.js
@@ -1,16 +1,16 @@
 import { access, constants, lstat, readdir, readFile, realpath, stat } from 'node:fs/promises';
-import { isAbsolute, join, relative, sep as dirSep } from 'node:path';
+import { isAbsolute, join, sep as dirSep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
 import { trimSlash } from './utils.js';
 
 /**
-@typedef {import('./types.d.ts').FSEntryBase} FSEntryBase
-@typedef {import('./types.d.ts').FSEntryKind} FSEntryKind
-@typedef {import('./types.d.ts').ErrorList} ErrorList
+@typedef {import('./types.d.ts').FSKind} FSKind
+@typedef {import('./types.d.ts').FSLocation} FSLocation
 */
 
-/** @type {(dirPath: string, context?: { error: ErrorList }) => Promise<boolean>} */
-export async function checkDirAccess(dirPath, context) {
+/** @type {(dirPath: string, context: { onError(msg: string): void }) => Promise<boolean>} */
+export async function checkDirAccess(dirPath, { onError }) {
 	let msg = '';
 	try {
 		const stats = await stat(dirPath);
@@ -30,11 +30,11 @@ export async function checkDirAccess(dirPath, context) {
 			msg = err.toString();
 		}
 	}
-	if (msg) context?.error(msg);
+	if (msg) onError(msg);
 	return false;
 }
 
-/** @type {(dirPath: string) => Promise<FSEntryBase[]>} */
+/** @type {(dirPath: string) => Promise<FSLocation[]>} */
 export async function getIndex(dirPath) {
 	try {
 		const entries = await readdir(dirPath, { withFileTypes: true });
@@ -47,7 +47,7 @@ export async function getIndex(dirPath) {
 	}
 }
 
-/** @type {(filePath: string) => Promise<FSEntryKind | null>} */
+/** @type {(filePath: string) => Promise<FSKind>} */
 export async function getKind(filePath) {
 	try {
 		const stats = await lstat(filePath);
@@ -75,7 +75,7 @@ export async function getRealpath(filePath) {
 	}
 }
 
-/** @type {(filePath: string, kind?: FSEntryKind | null) => Promise<boolean>} */
+/** @type {(filePath: string, kind?: FSKind) => Promise<boolean>} */
 export async function isReadable(filePath, kind) {
 	if (kind === undefined) {
 		kind = await getKind(filePath);
@@ -118,10 +118,10 @@ export async function readPkgJson() {
 	return JSON.parse(raw);
 }
 
-/** @type {(stats: import('node:fs').Dirent | import('node:fs').StatsBase<any>) => FSEntryKind | null} */
+/** @type {(stats: {isSymbolicLink?(): boolean; isDirectory?(): boolean; isFile?(): boolean}) => FSKind} */
 export function statsKind(stats) {
-	if (stats.isSymbolicLink()) return 'link';
-	if (stats.isDirectory()) return 'dir';
-	else if (stats.isFile()) return 'file';
+	if (stats.isSymbolicLink?.()) return 'link';
+	if (stats.isDirectory?.()) return 'dir';
+	else if (stats.isFile?.()) return 'file';
 	return null;
 }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,95 +1,65 @@
 import { Buffer } from 'node:buffer';
 import { createReadStream } from 'node:fs';
 import { open, stat } from 'node:fs/promises';
-import { createServer } from 'node:http';
 import { createGzip, gzipSync } from 'node:zlib';
 
 import { MAX_COMPRESS_SIZE, SUPPORTED_METHODS } from './constants.js';
 import { getContentType, typeForFilePath } from './content-type.js';
-import { getLocalPath, getRealpath, isSubpath } from './fs-utils.js';
+import { getLocalPath, isSubpath } from './fs-utils.js';
 import { dirListPage, errorPage } from './pages.js';
 import { PathMatcher } from './path-matcher.js';
-import { FileResolver } from './resolver.js';
 import { headerCase } from './utils.js';
 
 /**
-@typedef {import('node:fs/promises').FileHandle} FileHandle
-@typedef {import('node:http').IncomingMessage} IncomingMessage
-@typedef {import('node:http').ServerResponse} ServerResponse
-@typedef {import('./content-type.js').TypeResult} TypeResult
-@typedef {import('./types.d.ts').FSEntryBase} FSEntryBase
-@typedef {import('./types.d.ts').FSEntryKind} FSEntryKind
-@typedef {import('./types.d.ts').ReqResMeta} ReqResMeta
+@typedef {import('./types.d.ts').FSLocation} FSLocation
+@typedef {import('./types.d.ts').ResMetaData} ResMetaData
 @typedef {import('./types.d.ts').ServerOptions} ServerOptions
+*/
 
+/**
+@typedef {{
+	req: import('node:http').IncomingMessage;
+	res: import('node:http').ServerResponse<import('node:http').IncomingMessage>;
+	resolver: import('./resolver.js').FileResolver;
+	options: ServerOptions & {_noStream?: boolean}
+}} ReqHandlerConfig
 @typedef {{
 	body?: string | Buffer | import('node:fs').ReadStream;
+	contentType?: string;
 	isText?: boolean;
 	statSize?: number;
 }} SendPayload
 */
-
-/**
-@param {ServerOptions} options
-@param {{ logNetwork?: (data: ReqResMeta) => void }} [callbacks]
-@returns {import('node:http').Server}
-*/
-export function staticServer(options, { logNetwork } = {}) {
-	const resolver = new FileResolver(options);
-
-	return createServer(async (req, res) => {
-		const handler = new RequestHandler({ req, res }, resolver, options);
-		if (typeof logNetwork === 'function') {
-			res.on('close', () => logNetwork(handler.data()));
-		}
-		await handler.process();
-	});
-}
-
 export class RequestHandler {
 	#req;
 	#res;
-	#options;
 	#resolver;
+	#options;
 
-	/** @type {number} */
-	startedAt;
-	/** @type {number | undefined} */
-	endedAt;
-	/** @type {string} */
-	url = '';
+	/** @type {ResMetaData['timing']} */
+	timing = { start: Date.now() };
 	/** @type {string} */
 	urlPath = '';
-	/** @type {string | null} */
-	filePath = null;
-	/** @type {FSEntryKind | null} */
-	kind = null;
+	/** @type {FSLocation | null} */
+	file = null;
 	/**
 	Error that may be logged to the terminal
 	@type {Error | string | undefined}
 	*/
 	error;
 
-	/**
-	@param {{ req: IncomingMessage, res: ServerResponse }} reqRes
-	@param {FileResolver} resolver
-	@param {ServerOptions & {_noStream?: boolean}} options
-	*/
-	constructor({ req, res }, resolver, options) {
+	/** @param {ReqHandlerConfig} config */
+	constructor({ req, res, resolver, options }) {
 		this.#req = req;
 		this.#res = res;
 		this.#resolver = resolver;
 		this.#options = options;
-
-		this.startedAt = Date.now();
-		res.on('close', async () => {
-			this.endedAt = Date.now();
-		});
-
-		if (req.url) {
-			this.url = req.url;
+		if (typeof req.url === 'string') {
 			this.urlPath = req.url.split(/[\?\#]/)[0];
 		}
+		res.on('close', () => {
+			this.timing.close = Date.now();
+		});
 	}
 
 	get method() {
@@ -106,8 +76,8 @@ export class RequestHandler {
 		return this.#res.getHeaders();
 	}
 	get localPath() {
-		if (this.filePath != null) {
-			return getLocalPath(this.#options.root, this.filePath);
+		if (this.file) {
+			return getLocalPath(this.#options.root, this.file.filePath);
 		}
 		return null;
 	}
@@ -121,26 +91,25 @@ export class RequestHandler {
 		}
 
 		// no need to look up files for the '*' OPTIONS request
-		if (this.method === 'OPTIONS' && this.url === '*') {
+		if (this.method === 'OPTIONS' && this.urlPath === '*') {
 			this.status = 204;
 			this.#setHeaders('*', { cors: this.#options.cors });
 			return this.#send();
 		}
 
-		const { status, urlPath, filePath, kind } = await this.#resolver.find(this.url);
+		const { status, urlPath, file = null } = await this.#resolver.find(this.urlPath);
 		this.status = status;
 		this.urlPath = urlPath;
-		this.filePath = filePath;
-		this.kind = kind;
+		this.file = file;
 
 		// found a file to serve
-		if (status === 200 && filePath != null && kind === 'file') {
-			return this.#sendFile(filePath);
+		if (status === 200 && file?.kind === 'file') {
+			return this.#sendFile(file.filePath);
 		}
 
 		// found a directory that we can show a listing for
-		else if (status === 200 && filePath != null && kind === 'dir') {
-			return this.#sendListPage(filePath);
+		if (status === 200 && file?.kind === 'dir' && this.#options.dirList) {
+			return this.#sendListPage(file.filePath);
 		}
 
 		return this.#sendErrorPage();
@@ -148,12 +117,10 @@ export class RequestHandler {
 
 	/** @type {(filePath: string) => Promise<void>} */
 	async #sendFile(filePath) {
-		/** @type {FileHandle | undefined} */
+		/** @type {import('node:fs/promises').FileHandle | undefined} */
 		let handle;
-		/** @type {number | undefined} */
-		let statSize;
-		/** @type {TypeResult | undefined} */
-		let contentType;
+		/** @type {SendPayload} */
+		let data = {};
 
 		try {
 			// already checked in resolver, but better safe than sorry
@@ -162,8 +129,12 @@ export class RequestHandler {
 			}
 			// check that we can open the file (especially on windows where it might be busy)
 			handle = await open(filePath);
-			statSize = (await stat(filePath)).size;
-			contentType = await getContentType({ path: filePath, handle });
+			const type = await getContentType({ path: filePath, handle });
+			data = {
+				contentType: type.toString(),
+				isText: type.group === 'text',
+				statSize: (await stat(filePath)).size,
+			};
 		} catch (/** @type {any} */ err) {
 			this.status = err?.code === 'EBUSY' ? 403 : 500;
 			if (err && (err.message || typeof err === 'object')) this.error = err;
@@ -176,13 +147,10 @@ export class RequestHandler {
 		}
 
 		this.#setHeaders(filePath, {
-			contentType: contentType?.toString(),
+			contentType: data.contentType,
 			cors: this.#options.cors,
 			headers: this.#options.headers,
 		});
-
-		/** @type {SendPayload} */
-		const data = { isText: contentType?.group === 'text', statSize };
 
 		if (this.method === 'OPTIONS') {
 			this.status = 204;
@@ -231,6 +199,8 @@ export class RequestHandler {
 
 	/** @type {(payload?: SendPayload) => void} */
 	#send({ body, isText = false, statSize } = {}) {
+		this.timing.send = Date.now();
+
 		// stop early if possible
 		if (this.#req.destroyed) {
 			this.#res.end();
@@ -340,10 +310,16 @@ export class RequestHandler {
 		}
 	}
 
-	/** @type {() => ReqResMeta} */
+	/** @type {() => ResMetaData} */
 	data() {
-		const { status, method, url, urlPath, localPath, startedAt, endedAt, error } = this;
-		return { status, method, url, urlPath, localPath, startedAt, endedAt, error };
+		return {
+			status: this.status,
+			method: this.method,
+			urlPath: this.urlPath,
+			localPath: this.localPath,
+			timing: structuredClone(this.timing),
+			error: this.error,
+		};
 	}
 }
 
@@ -380,7 +356,7 @@ export function fileHeaders(localPath, rules, blockList = []) {
 	return result;
 }
 
-/** @type {(req: Pick<IncomingMessage, 'method' | 'headers'>) => boolean} */
+/** @type {(req: Pick<import('node:http').IncomingMessage, 'method' | 'headers'>) => boolean} */
 function isPreflight({ method, headers }) {
 	return (
 		method === 'OPTIONS' &&

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,7 @@ import { inspect } from 'node:util';
 import { clamp, fwdSlash, getEnv, trimSlash, withResolvers } from './utils.js';
 
 /**
-@typedef {import('./types.d.ts').ReqResMeta} ReqResMeta
+@typedef {import('./types.d.ts').ResMetaData} ResMetaData
 @typedef {{
 	group: 'header' | 'info' | 'request' | 'error';
 	text: string;
@@ -115,13 +115,14 @@ class Logger {
 	}
 }
 
-/** @type {(data: ReqResMeta) => string} */
-export function requestLogLine({ startedAt, endedAt, status, method, urlPath, localPath, error }) {
+/** @type {(data: import('./types.d.ts').ResMetaData) => string} */
+export function requestLogLine({ status, method, urlPath, localPath, timing, error }) {
+	const { start, close } = timing;
 	const { style: _, brackets } = color;
 
 	const isSuccess = status >= 200 && status < 300;
-	const timestamp = new Date(endedAt ?? startedAt).toTimeString().split(' ')[0]?.padStart(8);
-	const duration = endedAt && startedAt ? endedAt - startedAt : -1;
+	const timestamp = start ? new Date(start).toTimeString().split(' ')[0]?.padStart(8) : undefined;
+	const duration = start && close ? Math.ceil(close - start) : undefined;
 
 	let displayPath = _(urlPath, 'cyan');
 	if (isSuccess && localPath != null) {
@@ -134,14 +135,14 @@ export function requestLogLine({ startedAt, endedAt, status, method, urlPath, lo
 	}
 
 	const line = [
-		_(timestamp, 'dim'),
+		timestamp && _(timestamp, 'dim'),
 		_(`${status}`, isSuccess ? 'green' : 'red'),
 		_('—', 'dim'),
 		_(method, 'cyan'),
 		displayPath,
-		duration >= 0 ? _(`(${duration}ms)`, 'dim') : undefined,
+		duration && _(`(${duration}ms)`, 'dim'),
 	]
-		.filter(Boolean)
+		.filter((s) => typeof s === 'string' && s !== '')
 		.join(' ');
 
 	if (!isSuccess && error) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,15 +3,14 @@ import { isAbsolute, resolve } from 'node:path';
 import { DEFAULT_OPTIONS, PORTS_CONFIG } from './constants.js';
 
 /**
-@typedef {import('./types.d.ts').ErrorList} ErrorList
 @typedef {import('./types.d.ts').HttpHeaderRule} HttpHeaderRule
 @typedef {import('./types.d.ts').ServerOptions} ServerOptions
 */
 
 export class OptionsValidator {
-	/** @param {ErrorList} [errorList] */
-	constructor(errorList) {
-		this.errorList = errorList;
+	/** @param {(msg: string) => void} [onError] */
+	constructor(onError) {
+		this.onError = onError;
 	}
 
 	/**
@@ -34,7 +33,7 @@ export class OptionsValidator {
 	}
 
 	#error(msg = '') {
-		this.errorList?.(msg);
+		this.onError?.(msg);
 	}
 
 	/** @type {(input?: boolean) => boolean | undefined} */
@@ -171,11 +170,11 @@ export function isValidPort(num) {
 
 /**
 @param {{ root: string } & Partial<ServerOptions>} options
-@param {{ error: ErrorList }} [context]
+@param {{ onError(msg: string): void }} [context]
 @returns {ServerOptions}
 */
 export function serverOptions(options, context) {
-	const validator = new OptionsValidator(context?.error);
+	const validator = new OptionsValidator(context?.onError);
 
 	/** @type {Partial<ServerOptions>} */
 	const checked = {

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -4,7 +4,7 @@ import { readPkgFile } from './fs-utils.js';
 import { clamp, escapeHtml, trimSlash } from './utils.js';
 
 /**
-@typedef {import('./types.d.ts').DirIndexItem} DirIndexItem
+@typedef {import('./types.d.ts').FSLocation} FSLocation
 @typedef {import('./types.d.ts').ServerOptions} ServerOptions
 */
 
@@ -76,7 +76,7 @@ export function errorPage({ status, urlPath }) {
 }
 
 /**
-@param {{ urlPath: string; filePath: string; items: DirIndexItem[] }} data
+@param {{ urlPath: string; filePath: string; items: FSLocation[] }} data
 @param {Pick<ServerOptions, 'root' | 'ext'>} options
 @returns {Promise<string>}
 */
@@ -86,15 +86,12 @@ export function dirListPage({ urlPath, filePath, items }, options) {
 	const baseUrl = trimmedUrl ? `/${trimmedUrl}/` : '/';
 
 	const displayPath = decodeURIPathSegments(trimmedUrl ? `${rootName}/${trimmedUrl}` : rootName);
+	const parentPath = dirname(filePath);
+	const showParent = trimmedUrl !== '';
 
 	const sorted = [...items.filter((x) => isDirLike(x)), ...items.filter((x) => !isDirLike(x))];
-
-	if (trimmedUrl !== '') {
-		sorted.unshift({
-			filePath: dirname(filePath),
-			kind: 'dir',
-			isParent: true,
-		});
+	if (showParent) {
+		sorted.unshift({ filePath: parentPath, kind: 'dir' });
 	}
 
 	// Make sure we have at least 2 items to put in each CSS column
@@ -106,53 +103,54 @@ export function dirListPage({ urlPath, filePath, items }, options) {
 		base: baseUrl,
 		body: `
 <h1>
-	Index of <span class="bc">${htmlBreadcrumbs(displayPath)}</span>
+	Index of <span class="bc">${renderBreadcrumbs(displayPath)}</span>
 </h1>
 <ul class="files" style="--max-col-count:${maxCols}">
-${sorted.map((item) => dirListItem(item, options)).join('\n')}
+${sorted.map((item) => renderListItem(item, { ext: options.ext, parentPath })).join('\n')}
 </ul>
 `.trim(),
 	});
 }
 
 /**
-@type {(item: DirIndexItem, options: Pick<ServerOptions, 'ext'>) => string}
+@type {(item: FSLocation, options: { ext: ServerOptions['ext']; parentPath: string }) => string}
 */
-function dirListItem(item, { ext }) {
-	const { filePath, isParent = false } = item;
-	const isSymlink = item.kind === 'link';
-	const displayKind = isDirLike(item) ? 'dir' : 'file';
+function renderListItem(item, { ext, parentPath }) {
+	const isDir = isDirLike(item);
+	const isParent = isDir && item.filePath === parentPath;
 
-	const iconId = `icon-${displayKind}${isSymlink ? '-link' : ''}`;
-	const className = ['files-item', `files-item--${displayKind}`];
-	if (isParent) className.push('files-item--parent');
-	if (isSymlink) className.push('files-item--symlink');
-
-	const label = isParent ? 'Parent directory' : '';
-	const name = isParent ? '..' : basename(filePath);
-	const suffix = displayKind === 'dir' ? '/' : '';
-
-	// clean url: remove extension if possible
+	let icon = isDir ? 'icon-dir' : 'icon-file';
+	if (item.kind === 'link') icon += '-link';
+	let name = basename(item.filePath);
+	let suffix = '';
+	let label = '';
 	let href = encodeURIComponent(name);
-	if (displayKind === 'file') {
-		const match = ext.find((e) => filePath.endsWith(e));
+
+	if (isParent) {
+		name = '..';
+		href = '..';
+		label = 'Parent directory';
+	}
+	if (isDir) {
+		suffix = '/';
+	} else {
+		// clean url: remove extension if possible
+		const match = ext.find((e) => item.filePath.endsWith(e));
 		if (match) href = href.slice(0, href.length - match.length);
 	}
 
-	const parts = [
-		`<li class="${attr(className.join(' '))}">\n`,
+	return [
+		`<li class="files-item">\n`,
 		`<a class="files-link" href="${attr(href)}"${label && ` aria-label="${attr(label)}" title="${attr(label)}"`}>`,
-		`<svg class="files-icon" width="20" height="20"><use xlink:href="#${attr(iconId)}"></use></svg>`,
+		`<svg class="files-icon" width="20" height="20"><use xlink:href="#${attr(icon)}"></use></svg>`,
 		`<span class="files-name filepath">${html(nl2sp(name))}${suffix && `<span>${html(suffix)}</span>`}</span>`,
 		`</a>`,
 		`\n</li>`,
-	];
-
-	return parts.join('');
+	].join('');
 }
 
 /** @type {(path: string) => string} */
-function htmlBreadcrumbs(path) {
+function renderBreadcrumbs(path) {
 	const slash = '<span class="bc-sep">/</span>';
 	return path
 		.split('/')
@@ -168,7 +166,7 @@ function htmlBreadcrumbs(path) {
 		.join(slash);
 }
 
-/** @type {(item: DirIndexItem) => boolean} */
+/** @type {(item: FSLocation) => boolean} */
 function isDirLike(item) {
 	return item.kind === 'dir' || (item.kind === 'link' && item.target?.kind === 'dir');
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -5,9 +5,7 @@ import { PathMatcher } from './path-matcher.js';
 import { fwdSlash, trimSlash } from './utils.js';
 
 /**
-@typedef {import('./types.d.ts').DirIndexItem} DirIndexItem
-@typedef {import('./types.d.ts').FSEntryBase} FSEntryBase
-@typedef {import('./types.d.ts').ResolveResult} ResolveResult
+@typedef {import('./types.d.ts').FSLocation} FSLocation
 @typedef {import('./types.d.ts').ServerOptions} ServerOptions
 */
 
@@ -41,17 +39,12 @@ export class FileResolver {
 		this.#excludeMatcher = new PathMatcher(options.exclude ?? [], { caseSensitive: true });
 	}
 
-	/** @type {(url: string) => Promise<ResolveResult>} */
+	/** @param {string} url */
 	async find(url) {
 		const { urlPath, filePath: targetPath } = resolveUrlPath(this.#root, url);
 
-		/** @type {ResolveResult} */
-		const result = {
-			urlPath,
-			status: 404,
-			filePath: null,
-			kind: null,
-		};
+		/** @type {{status: number; urlPath: string; file?: FSLocation}} */
+		const result = { status: 404, urlPath };
 
 		if (targetPath == null) {
 			return result;
@@ -69,12 +62,9 @@ export class FileResolver {
 
 		// We have a match
 		if (file.kind === 'file' || file.kind === 'dir') {
-			Object.assign(result, file);
-		}
-
-		// Check permissions (directories are always a 404 if dirList is false)
-		if (file.kind === 'file' || (file.kind === 'dir' && this.#dirList)) {
-			const allowed = this.allowedPath(file.filePath);
+			result.file = file;
+			const allowed =
+				file.kind === 'dir' && !this.#dirList ? false : this.allowedPath(file.filePath);
 			const readable = allowed && (await isReadable(file.filePath, file.kind));
 			result.status = allowed ? (readable ? 200 : 403) : 404;
 		}
@@ -82,11 +72,11 @@ export class FileResolver {
 		return result;
 	}
 
-	/** @type {(dirPath: string) => Promise<DirIndexItem[]>} */
+	/** @type {(dirPath: string) => Promise<FSLocation[]>} */
 	async index(dirPath) {
 		if (!this.#dirList) return [];
 
-		/** @type {DirIndexItem[]} */
+		/** @type {FSLocation[]} */
 		const items = (await getIndex(dirPath)).filter(
 			(item) => item.kind != null && this.allowedPath(item.filePath),
 		);
@@ -109,7 +99,7 @@ export class FileResolver {
 	}
 
 	/**
-	@type {(filePath: string[]) => Promise<FSEntryBase | void>}
+	@type {(filePath: string[]) => Promise<FSLocation | void>}
 	*/
 	async locateAltFiles(filePaths) {
 		for (const filePath of filePaths) {
@@ -124,7 +114,7 @@ export class FileResolver {
 	/**
 	Locate a file or alternative files that can be served for a resource,
 	using the config for extensions and index file lookup.
-	@type {(filePath: string) => Promise<FSEntryBase>}
+	@type {(filePath: string) => Promise<FSLocation>}
 	*/
 	async locateFile(filePath) {
 		if (!this.withinRoot(filePath)) {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,18 +1,9 @@
-export type DirIndexItem = FSEntryBase & {
-	isParent?: boolean;
-	target?: FSEntryBase;
-};
+export type FSKind = 'dir' | 'file' | 'link' | null;
 
-export interface ErrorList {
-	(msg: string): void;
-	list: string[];
-}
-
-export type FSEntryKind = 'dir' | 'file' | 'link';
-
-export interface FSEntryBase {
+export interface FSLocation {
 	filePath: string;
-	kind: FSEntryKind | null;
+	kind: FSKind;
+	target?: { filePath: string; kind: FSKind };
 }
 
 export interface HttpHeaderRule {
@@ -27,44 +18,14 @@ export interface OptionSpec {
 	default?: string | string[];
 }
 
-export type OptionSpecs = Record<
-	| 'cors'
-	| 'dirFile'
-	| 'dirList'
-	| 'exclude'
-	| 'ext'
-	| 'gzip'
-	| 'header'
-	| 'help'
-	| 'host'
-	| 'port'
-	| 'version',
-	OptionSpec
->;
-
-export interface PortsConfig {
-	initial: number;
-	count: number;
-	maxCount: number;
-}
-
-export interface ResolveResult {
-	status: number;
-	urlPath: string;
-	filePath: string | null;
-	kind: FSEntryKind | null;
-}
-
-export type ReqResMeta = {
+export interface ResMetaData {
 	method: string;
 	status: number;
-	url: string;
 	urlPath: string;
 	localPath: string | null;
-	startedAt: number;
-	endedAt?: number;
+	timing: { start: number; send?: number; close?: number };
 	error?: Error | string;
-};
+}
 
 export interface HttpOptions {
 	host: string;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,5 @@
 import { env, versions } from 'node:process';
 
-/**
-@typedef {import('./types.d.ts').ErrorList} ErrorList
-*/
-
 /** @type {(value: number, min: number, max: number) => number} */
 export function clamp(value, min, max) {
 	if (typeof value !== 'number') value = min;
@@ -18,7 +14,7 @@ export function escapeHtml(input, context = 'text') {
 	return result;
 }
 
-/** @type {() => ErrorList} */
+/** @type {() => { (msg: string): void; list: string[] }} */
 export function errorList() {
 	/** @type {string[]} */
 	const list = [];

--- a/test/fs-utils.test.js
+++ b/test/fs-utils.test.js
@@ -18,7 +18,7 @@ const isWindows = platform() === 'win32';
 suite('fsUtils', async () => {
 	// creating symlinks throws on Windows when not running as admin,
 	// so we'll have to skip all symlink testing on Windows.
-	const { fixture, root } = await fsFixture({
+	const { fixture, path } = await fsFixture({
 		'blocked/file.txt': '!!!',
 		'blocked/link.txt': isWindows ? '' : ({ symlink }) => symlink('./file.txt'),
 		'index.html': '<h1>Hello</h1>',
@@ -33,47 +33,47 @@ suite('fsUtils', async () => {
 	after(() => fixture.rm());
 
 	test('getIndex', async () => {
-		const rootIndex = await getIndex(root());
+		const rootIndex = await getIndex(path());
 		deepStrictEqual(rootIndex, [
-			{ filePath: root`blocked`, kind: 'dir' },
-			{ filePath: root`index.html`, kind: 'file' },
-			{ filePath: root`page1.html`, kind: 'file' },
-			{ filePath: root`section1`, kind: 'dir' },
-			{ filePath: root`section2`, kind: 'dir' },
+			{ filePath: path`blocked`, kind: 'dir' },
+			{ filePath: path`index.html`, kind: 'file' },
+			{ filePath: path`page1.html`, kind: 'file' },
+			{ filePath: path`section1`, kind: 'dir' },
+			{ filePath: path`section2`, kind: 'dir' },
 		]);
 
-		const sectionIndex = await getIndex(root`section1`);
+		const sectionIndex = await getIndex(path`section1`);
 		deepStrictEqual(sectionIndex, [
-			{ filePath: root`section1/index.html`, kind: 'file' },
-			{ filePath: root`section1/other-page.html`, kind: 'file' },
-			{ filePath: root`section1/sub-section`, kind: 'dir' },
+			{ filePath: path`section1/index.html`, kind: 'file' },
+			{ filePath: path`section1/other-page.html`, kind: 'file' },
+			{ filePath: path`section1/sub-section`, kind: 'dir' },
 		]);
 	});
 
 	test('getKind', async () => {
-		strictEqual(await getKind(root``), 'dir');
-		strictEqual(await getKind(root`section1`), 'dir');
-		strictEqual(await getKind(root`index.html`), 'file');
-		strictEqual(await getKind(root`section1/sub-section/index.html`), 'file');
-		strictEqual(await getKind(root`section2/link.html`), isWindows ? 'file' : 'link');
+		strictEqual(await getKind(path``), 'dir');
+		strictEqual(await getKind(path`section1`), 'dir');
+		strictEqual(await getKind(path`index.html`), 'file');
+		strictEqual(await getKind(path`section1/sub-section/index.html`), 'file');
+		strictEqual(await getKind(path`section2/link.html`), isWindows ? 'file' : 'link');
 	});
 
 	test('getRealpath', async () => {
-		strictEqual(await getRealpath(root``), root``);
-		strictEqual(await getRealpath(root`page1.html`), root`page1.html`);
+		strictEqual(await getRealpath(path``), path``);
+		strictEqual(await getRealpath(path`page1.html`), path`page1.html`);
 		strictEqual(
-			await getRealpath(root`section2/link.html`),
-			isWindows ? root`section2/link.html` : root`page1.html`,
+			await getRealpath(path`section2/link.html`),
+			isWindows ? path`section2/link.html` : path`page1.html`,
 		);
 	});
 
 	test('isReadable(file)', async () => {
-		strictEqual(await isReadable(root``), true);
-		strictEqual(await isReadable(root`page1.html`), true);
-		strictEqual(await isReadable(root`section1/sub-section`), true);
+		strictEqual(await isReadable(path``), true);
+		strictEqual(await isReadable(path`page1.html`), true);
+		strictEqual(await isReadable(path`section1/sub-section`), true);
 
 		// make one file unreadable
-		const blockedPath = root`blocked/file.txt`;
+		const blockedPath = path`blocked/file.txt`;
 		strictEqual(await isReadable(blockedPath), true);
 		if (!isWindows) {
 			await chmod(blockedPath, 0o000);
@@ -83,8 +83,8 @@ suite('fsUtils', async () => {
 		// symlinks reflect the readable state of their target
 		// (caveat: does not check +x permission if target is a dir)
 		if (!isWindows) {
-			strictEqual(await isReadable(root`section2/link.html`), true);
-			strictEqual(await isReadable(root`blocked/link.txt`), false);
+			strictEqual(await isReadable(path`section2/link.html`), true);
+			strictEqual(await isReadable(path`blocked/link.txt`), false);
 		}
 	});
 });

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -2,7 +2,6 @@ import { strictEqual } from 'node:assert';
 import { suite, test } from 'node:test';
 
 import { ColorUtils, requestLogLine, stripStyle } from '../lib/logger.js';
-import { file } from './shared.js';
 
 suite('ColorUtils', () => {
 	const color = new ColorUtils(true);
@@ -52,21 +51,15 @@ suite('ColorUtils', () => {
 	});
 });
 
-/**
-@typedef {import('../lib/types.d.ts').ReqResMeta} ReqResMeta
-*/
-
 suite('responseLogLine', () => {
 	/**
-	@param {Omit<ReqResMeta, 'startedAt' | 'endedAt' | 'urlPath'>} data
+	@param {Omit<import('../lib/types.d.ts').ResMetaData, 'timing'>} data
 	@param {string} expected
 	*/
 	const matchLogLine = (data, expected) => {
 		const rawLine = requestLogLine({
+			timing: { start: Date.now() },
 			...data,
-			urlPath: data.url.split(/[\?\#]/)[0],
-			startedAt: Date.now(),
-			endedAt: undefined,
 		});
 		const line = stripStyle(rawLine).replace(/^\d{2}:\d{2}:\d{2} /, '');
 		strictEqual(line, expected);
@@ -77,7 +70,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				url: '/',
+				urlPath: '/',
 				localPath: '',
 			},
 			'200 — GET /',
@@ -86,7 +79,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 404,
-				url: '/favicon.ico',
+				urlPath: '/favicon.ico',
 				localPath: null,
 			},
 			`404 — GET /favicon.ico`,
@@ -95,7 +88,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 403,
-				url: '/.htaccess',
+				urlPath: '/.htaccess',
 				localPath: '.htaccess',
 			},
 			`403 — GET /.htaccess`,
@@ -107,7 +100,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				url: '/',
+				urlPath: '/',
 				localPath: 'index.html',
 			},
 			`200 — GET /[index.html]`,
@@ -116,7 +109,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				url: '/some/page',
+				urlPath: '/some/page',
 				localPath: 'some/page.htm',
 			},
 			`200 — GET /some/page[.htm]`,
@@ -125,7 +118,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				url: '/other/page/',
+				urlPath: '/other/page/',
 				localPath: 'other\\page.html',
 			},
 			`200 — GET /other/page[.html]/`,
@@ -134,7 +127,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'POST',
 				status: 201,
-				url: '/api/hello',
+				urlPath: '/api/hello',
 				localPath: 'api\\hello.json',
 			},
 			`201 — POST /api/hello[.json]`,
@@ -146,7 +139,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				url: '/',
+				urlPath: '/',
 				localPath: '',
 			},
 			`200 — GET /`,
@@ -155,7 +148,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				url: '/section1',
+				urlPath: '/section1',
 				localPath: 'section1',
 			},
 			`200 — GET /section1`,
@@ -164,7 +157,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 200,
-				url: '/a/b/c/d/',
+				urlPath: '/a/b/c/d/',
 				localPath: 'a\\b\\c\\d',
 			},
 			`200 — GET /a/b/c/d/`,
@@ -176,7 +169,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 403,
-				url: '/.env',
+				urlPath: '/.env',
 				localPath: '.env',
 			},
 			`403 — GET /.env`,
@@ -185,7 +178,7 @@ suite('responseLogLine', () => {
 			{
 				method: 'GET',
 				status: 404,
-				url: '/robots.txt',
+				urlPath: '/robots.txt',
 				localPath: 'robots.txt',
 			},
 			`404 — GET /robots.txt`,

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -198,14 +198,14 @@ suite('isValidPort', () => {
 
 suite('serverOptions', () => {
 	test('returns default options with empty input', () => {
-		const context = { error: errorList() };
-		const { root, ...result } = serverOptions({ root: cwd() }, context);
+		const onError = errorList();
+		const { root, ...result } = serverOptions({ root: cwd() }, { onError });
 		deepStrictEqual(result, DEFAULT_OPTIONS);
-		deepStrictEqual(context.error.list, []);
+		deepStrictEqual(onError.list, []);
 	});
 
 	test('preserves valid options', () => {
-		const context = { error: errorList() };
+		const onError = errorList();
 
 		/** @type {Parameters<serverOptions>[0]} */
 		const testOptions1 = {
@@ -214,7 +214,7 @@ suite('serverOptions', () => {
 			gzip: false,
 			cors: true,
 		};
-		deepStrictEqual(serverOptions(testOptions1, context), {
+		deepStrictEqual(serverOptions(testOptions1, { onError }), {
 			...DEFAULT_OPTIONS,
 			...testOptions1,
 		});
@@ -228,16 +228,16 @@ suite('serverOptions', () => {
 			headers: [{ include: ['*.md', '*.html'], headers: { dnt: 1 } }],
 			host: '192.168.1.199',
 		};
-		deepStrictEqual(serverOptions(testOptions2, context), {
+		deepStrictEqual(serverOptions(testOptions2, { onError }), {
 			...DEFAULT_OPTIONS,
 			...testOptions2,
 		});
 
-		deepStrictEqual(context.error.list, []);
+		deepStrictEqual(onError.list, []);
 	});
 
 	test('rejects invalid values', () => {
-		const context = { error: errorList() };
+		const onError = errorList();
 		const inputs = {
 			root: 'this/path/doesnt/exist',
 			cors: null,
@@ -253,7 +253,7 @@ suite('serverOptions', () => {
 		const { root, ...result } = serverOptions(
 			// @ts-expect-error
 			inputs,
-			context,
+			{ onError },
 		);
 		ok(typeof root === 'string');
 		ok(Object.keys(result).length >= 9);

--- a/test/pages.test.js
+++ b/test/pages.test.js
@@ -3,7 +3,7 @@ import { deepStrictEqual, ok, strictEqual } from 'node:assert';
 import { suite, test } from 'node:test';
 
 import { dirListPage, errorPage } from '../lib/pages.js';
-import { file, link, testPath } from './shared.js';
+import { loc } from './shared.js';
 
 /**
 @type {(doc: Document, selector: string) => string | undefined}
@@ -34,7 +34,7 @@ function checkTemplate(doc, content) {
 }
 
 suite('dirListPage', () => {
-	const serverOptions = { root: testPath(), ext: ['.html'] };
+	const serverOptions = { root: loc.path(), ext: ['.html'] };
 
 	/**
 	@type {(data: Parameters<typeof dirListPage>[0]) => Promise<Document>}
@@ -62,7 +62,7 @@ suite('dirListPage', () => {
 	test('empty list page (root)', async () => {
 		const doc = await dirListDoc({
 			urlPath: '/',
-			filePath: testPath(''),
+			filePath: loc.path(),
 			items: [],
 		});
 		const list = doc.querySelector('ul');
@@ -76,7 +76,7 @@ suite('dirListPage', () => {
 		const localPath = 'cool/folder';
 		const doc = await dirListDoc({
 			urlPath: `/${localPath}`,
-			filePath: testPath(localPath),
+			filePath: loc.path(localPath),
 			items: [],
 		});
 		const list = doc.querySelector('ul');
@@ -90,14 +90,14 @@ suite('dirListPage', () => {
 	test('list page with items', async () => {
 		const doc = await dirListDoc({
 			urlPath: '/section',
-			filePath: testPath('section'),
+			filePath: loc.path('section'),
 			items: [
-				file('section/  I have spaces  '),
-				file('section/.gitignore'),
-				link('section/CHANGELOG', file('section/docs/changelog.md')),
-				file('section/Library', 'dir'),
-				link('section/public', file('section/.vitepress/build', 'dir')),
-				file('section/README.md'),
+				loc.file('section/  I have spaces  '),
+				loc.file('section/.gitignore'),
+				loc.file('section/CHANGELOG', loc.file('section/docs/changelog.md')),
+				loc.dir('section/Library'),
+				loc.file('section/public', loc.dir('section/.vitepress/build')),
+				loc.file('section/README.md'),
 			],
 		});
 


### PR DESCRIPTION
- De-duplicate or remove some of the shared types in `lib/types.d.ts`.
- Remove `createServer` function in `lib/server.js`, and create the server in `lib/cli.js` instead.
- Rename `context.error` callback to `context.onError`.