### PR TITLE
fix(deno): bundle assets to avoid permission prompt

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,5 @@
 import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
 import { homedir, networkInterfaces } from 'node:os';
 import { sep as dirSep } from 'node:path';
 import process, { argv, exit, platform, stdin } from 'node:process';
@@ -6,7 +7,7 @@ import { emitKeypressEvents } from 'node:readline';
 
 import { CLIArgs, parseArgs } from './args.js';
 import { CLI_OPTIONS, HOSTS_LOCAL, HOSTS_WILDCARD } from './constants.js';
-import { checkDirAccess, pkgFilePath, readPkgJson } from './fs-utils.js';
+import { checkDirAccess, readPkgJson } from './fs-utils.js';
 import { RequestHandler } from './handler.js';
 import { color, logger, requestLogLine } from './logger.js';
 import { serverOptions } from './options.js';
@@ -25,7 +26,7 @@ export async function run() {
 	const args = new CLIArgs(argv.slice(2));
 
 	if (args.has('--version')) {
-		const pkg = await readPkgJson();
+		const pkg = readPkgJson();
 		logger.write('info', pkg.version);
 		process.exitCode = 0;
 		return;
@@ -38,13 +39,7 @@ export async function run() {
 	const onError = errorList();
 	const userOptions = parseArgs(args, { onError });
 	const options = serverOptions({ root: '', ...userOptions }, { onError });
-
 	await checkDirAccess(options.root, { onError });
-	// check access to assets needed by server pages,
-	// to trigger a permission prompt before the server starts
-	if (getRuntime() === 'deno') {
-		await checkDirAccess(pkgFilePath('assets'), { onError: () => {} });
-	}
 
 	if (onError.list.length) {
 		logger.error(...onError.list);

--- a/lib/fs-utils.js
+++ b/lib/fs-utils.js
@@ -1,6 +1,6 @@
-import { access, constants, lstat, readdir, readFile, realpath, stat } from 'node:fs/promises';
+import { access, constants, lstat, readdir, realpath, stat } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { isAbsolute, join, sep as dirSep } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { trimSlash } from './utils.js';
 
@@ -97,25 +97,9 @@ export function isSubpath(parent, filePath) {
 	return filePath === parent || filePath.startsWith(parent + dirSep);
 }
 
-/** @type {(moduleUrl: URL | string) => string} */
-export function moduleDirname(moduleUrl) {
-	return fileURLToPath(new URL('.', moduleUrl));
-}
-
-/** @type {(localPath: string) => string} */
-export function pkgFilePath(localPath) {
-	return join(moduleDirname(import.meta.url), '..', localPath);
-}
-
-/** @type {(localPath: string) => Promise<string>} */
-export async function readPkgFile(localPath) {
-	return readFile(pkgFilePath(localPath), { encoding: 'utf8' });
-}
-
-/** @type {() => Promise<Record<string, any>>} */
-export async function readPkgJson() {
-	const raw = await readPkgFile('package.json');
-	return JSON.parse(raw);
+/** @type {() => Record<string, any>} */
+export function readPkgJson() {
+	return createRequire(import.meta.url)('../package.json');
 }
 
 /** @type {(stats: {isSymbolicLink?(): boolean; isDirectory?(): boolean; isFile?(): boolean}) => FSKind} */

--- a/lib/page-assets.js
+++ b/lib/page-assets.js
@@ -1,0 +1,204 @@
+export const FAVICON_ERROR = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+<style>
+svg { fill: #333 }
+@media (prefers-color-scheme: dark) {
+svg { fill: #ccc }
+}
+</style>
+<path fill-rule="evenodd" d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12Zm0 1.5a7.5 7.5 0 1 0 0-15 7.5 7.5 0 0 0 0 15Z M9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM7 5a1 1 0 0 1 2 0v3a1 1 0 0 1-2 0V5Z"/>
+</svg>`;
+
+export const FAVICON_LIST = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+<style>
+svg { fill: #333 }
+@media (prefers-color-scheme: dark) {
+svg { fill: #ccc }
+}
+</style>
+<rect x="1" y="2.75" width="2" height="2" rx="1"/>
+<rect x="1" y="7.25" width="2" height="2" rx="1"/>
+<rect x="1" y="11.75" width="2" height="2" rx="1"/>
+<rect x="5" y="3" width="8.5" height="1.5" rx="0.75"/>
+<rect x="5" y="7.5" width="10" height="1.5" rx="0.75"/>
+<rect x="5" y="12" width="7" height="1.5" rx="0.75"/>
+</svg>`;
+
+export const ICONS = `<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" style="position:absolute;pointer-events:none">
+<symbol id="icon-dir" viewBox="0 0 20 20">
+<path d="M8.886 3.658A.5.5 0 0 0 9.36 4H17a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h3.558a2 2 0 0 1 1.898 1.368l.43 1.29ZM3 16.5h14a.5.5 0 0 0 .5-.5V6a.5.5 0 0 0-.5-.5H9.36a2 2 0 0 1-1.897-1.368l-.43-1.29a.5.5 0 0 0-.475-.342H3a.5.5 0 0 0-.5.5v13a.5.5 0 0 0 .5.5Z"/>
+</symbol>
+<symbol id="icon-dir-link" viewBox="0 0 20 20">
+<path d="M8.886 3.658A.5.5 0 0 0 9.36 4H17a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h3.558a2 2 0 0 1 1.898 1.368l.43 1.29ZM3 16.5h14a.5.5 0 0 0 .5-.5V6a.5.5 0 0 0-.5-.5H9.36a2 2 0 0 1-1.897-1.368l-.43-1.29a.5.5 0 0 0-.475-.342H3a.5.5 0 0 0-.5.5v13a.5.5 0 0 0 .5.5Z M7.5 9.75a.75.75 0 0 0-1.5 0V11a2 2 0 0 0 2 2h3v1a.5.5 0 0 0 .812.39l2.5-2a.5.5 0 0 0 0-.78l-2.5-2A.5.5 0 0 0 11 10v1.5H8a.5.5 0 0 1-.5-.5V9.75Z"/>
+</symbol>
+<symbol id="icon-file" viewBox="0 0 20 20">
+<path fill-rule="evenodd" d="M9.5 6.75V2.5H4a.5.5 0 0 0-.5.5v14a.5.5 0 0 0 .5.5h12a.5.5 0 0 0 .5-.5V8.5h-5.25A1.75 1.75 0 0 1 9.5 6.75ZM11 2.976V6.75c0 .138.112.25.25.25h4.445L11 2.976ZM2 3v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.92a2 2 0 0 0-.698-1.519l-5.74-4.92A2 2 0 0 0 10.26 1H4a2 2 0 0 0-2 2Z"/>
+</symbol>
+<symbol id="icon-file-link" viewBox="0 0 20 20">
+<path fill-rule="evenodd" d="M9.5 6.75V2.5H4a.5.5 0 0 0-.5.5v14a.5.5 0 0 0 .5.5h12a.5.5 0 0 0 .5-.5V8.5h-5.25A1.75 1.75 0 0 1 9.5 6.75ZM11 2.976V6.75c0 .138.112.25.25.25h4.445L11 2.976ZM2 3v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.92a2 2 0 0 0-.698-1.519l-5.74-4.92A2 2 0 0 0 10.26 1H4a2 2 0 0 0-2 2Z M7.5 10.75a.75.75 0 0 0-1.5 0V12a2 2 0 0 0 2 2h3v1a.5.5 0 0 0 .812.39l2.5-2a.5.5 0 0 0 0-.78l-2.5-2A.5.5 0 0 0 11 11v1.5H8a.5.5 0 0 1-.5-.5v-1.25Z"/>
+</symbol>
+</svg>`;
+
+export const STYLES = `@property --max-col-count {
+syntax: '<integer>';
+inherits: true;
+initial-value: 4;
+}
+* {
+box-sizing: border-box;
+}
+:root {
+--bg-base: hsl(0 0% 98%);
+--text-base: hsl(0 0% 8%);
+--text-secondary: hsl(0 0% 28%);
+--text-highlight: hsl(330 60% 33%);
+--text-link: hsl(210 85% 40%);
+--border-dim: hsl(0 0% 80%);
+color: var(--text-base);
+background-color: var(--bg-base);
+tab-size: 4;
+}
+@media (prefers-contrast: more) {
+:root {
+--bg-base: hsl(0 0% 98%);
+--text-base: hsl(0 0% 4%);
+--text-secondary: hsl(0 0% 16%);
+--text-highlight: hsl(330, 70%, 28%);
+--text-link: hsl(210, 86%, 30%);
+--border-dim: hsl(0 0% 40%);
+}
+}
+body {
+margin: 0;
+padding: 1.5rem;
+line-height: 1.5;
+font-family: system-ui, sans-serif;
+}
+@media (min-width: 40em) {
+body {
+padding: 3rem 3.5rem;
+}
+}
+h1 {
+margin-block: 0 1.5rem;
+font-size: 1.125rem;
+font-weight: 500;
+line-height: 1.5;
+}
+p {
+margin-block: 0;
+padding-block: 0.5rem;
+color: var(--text-secondary);
+}
+code {
+font-size-adjust: ex-height 0.525;
+font-family: ui-monospace, monospace;
+font-size: 100%;
+color: var(--text-highlight);
+}
+.filepath {
+white-space-collapse: preserve;
+word-break: break-word;
+hyphenate-character: '';
+}
+code.filepath {
+border: solid 1px #ccc;
+padding: 2px 4px;
+border-radius: 4px;
+margin-inline: 2px;
+}
+.bc-current,
+.bc-link {
+padding: 4px 2px;
+border-radius: 4px;
+color: inherit;
+}
+.bc-link {
+text-decoration: underline;
+text-decoration-thickness: 1px;
+text-decoration-color: #ccc;
+text-underline-offset: 6px;
+}
+.bc-link:hover {
+color: var(--text-link);
+text-decoration-color: currentColor;
+}
+.bc-link:focus-visible {
+color: var(--text-link);
+outline: solid 2px currentColor;
+outline-offset: -2px;
+}
+.bc-sep {
+font-weight: 400;
+opacity: 0.5;
+}
+.files {
+margin-block: 1rem;
+margin-inline: -0.75rem;
+padding-inline: 0;
+list-style: none;
+font-variant-numeric: tabular-nums;
+}
+/*
+tweaking font sizes to fractional sizes may defeat font hinting,
+which could look bad on low resolution screens
+*/
+@media (min-resolution: 1.5x) {
+.files {
+font-size: 0.96875rem;
+}
+}
+@media (min-width: 40em) {
+.files {
+max-width: max(30rem, var(--max-col-count) * 22.5rem + calc(var(--max-col-count) - 1) * 1rem);
+column-count: var(--max-col-count);
+column-width: 22.5rem;
+column-gap: 1rem;
+}
+}
+.files-item {
+max-width: 30rem;
+break-inside: avoid;
+}
+.files-link {
+--icon-opacity: 0.8;
+display: flex;
+gap: 0.75rem;
+align-items: center;
+min-height: 2.5rem;
+border-radius: 4px;
+padding: 0.375rem 0.75rem;
+line-height: 1.125rem;
+color: var(--text-base);
+}
+.files-link:not(:hover) {
+text-decoration: none;
+}
+.files-link:hover {
+--icon-opacity: 1;
+color: var(--text-link);
+}
+.files-link:focus-visible {
+--icon-opacity: 1;
+color: var(--text-link);
+outline: solid 2px currentColor;
+outline-offset: -2px;
+}
+.files-icon {
+flex: none;
+fill: currentColor;
+opacity: var(--icon-opacity);
+}
+.files-name {
+display: block;
+}
+.files-link[aria-label*='parent' i] .files-name {
+letter-spacing: 0.15ch;
+}
+.files-name > span {
+margin-inline-start: 0.2ch;
+}
+@media (prefers-contrast: no-preference) {
+.files-name > span {
+opacity: 0.6;
+}
+}`;

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -1,6 +1,6 @@
 import { basename, dirname } from 'node:path';
 
-import { readPkgFile } from './fs-utils.js';
+import { FAVICON_LIST, FAVICON_ERROR, ICONS, STYLES } from './page-assets.js';
 import { clamp, escapeHtml, trimSlash } from './utils.js';
 
 /**
@@ -8,28 +8,11 @@ import { clamp, escapeHtml, trimSlash } from './utils.js';
 @typedef {import('./types.d.ts').ServerOptions} ServerOptions
 */
 
-/** @type {Map<string, string>} */
-const assetCache = new Map();
-
-/** @type {(localPath: string) => Promise<string>} */
-export async function readAsset(localPath) {
-	if (!assetCache.has(localPath)) {
-		assetCache.set(localPath, await readPkgFile(localPath));
-	}
-	return assetCache.get(localPath) ?? '';
-}
-
 /**
-@typedef {{ base?: string; body: string; icon?: 'list' | 'error'; title?: string }} HtmlTemplateData
-@type {(data: HtmlTemplateData) => Promise<string>}
+@param {{ base?: string; body: string; icon?: 'list' | 'error'; title?: string }} data
 */
 async function htmlTemplate({ base, body, icon, title }) {
-	const [css, svgSprite, svgIcon] = await Promise.all([
-		readAsset('assets/styles.css'),
-		readAsset('assets/icons.svg'),
-		icon === 'list' || icon === 'error' ? readAsset(`assets/favicon-${icon}.svg`) : undefined,
-	]);
-
+	const svgIcon = { list: FAVICON_LIST, error: FAVICON_ERROR }[String(icon)];
 	return `<!doctype html>
 <html lang="en">
 <head>
@@ -38,10 +21,10 @@ ${title ? `<title>${html(title)}</title>` : ''}
 ${base ? `<base href="${attr(base)}">` : ''}
 <meta name="viewport" content="width=device-width">
 ${svgIcon ? `<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,${btoa(svgIcon)}">` : ''}
-<style>${css.toString()}</style>
+<style>${STYLES}</style>
 </head>
 <body>
-${svgSprite.toString()}
+${ICONS}
 ${body}
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
 		"servitsy": "bin/servitsy.js"
 	},
 	"files": [
-		"./assets",
 		"./bin",
 		"./lib",
 		"./LICENSE",
 		"./README.md"
 	],
 	"scripts": {
+		"prepack": "npm run build && npm run typecheck && npm test",
+		"build": "node scripts/bundle.js",
 		"format": "prettier --write '**/*.{js,css}' '**/*config*.json'",
 		"test": "node --test --test-reporter=spec",
 		"typecheck": "tsc -p jsconfig.json && tsc -p test/jsconfig.json"

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -1,0 +1,36 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+bundleAssets();
+
+/**
+Read text files from the assets folder and write
+*/
+async function bundleAssets() {
+	const outPath = 'lib/page-assets.js';
+	const assets = {
+		FAVICON_ERROR: await readPkgFile('assets/favicon-error.svg'),
+		FAVICON_LIST: await readPkgFile('assets/favicon-list.svg'),
+		ICONS: await readPkgFile('assets/icons.svg'),
+		STYLES: await readPkgFile('assets/styles.css'),
+	};
+	const minify = (input = '') => input.replace(/^\s+/gm, '').trim();
+	const escape = (input = '') => input.replace(/\`/g, '\\`');
+
+	const out = Object.entries(assets).map(([key, contents]) => {
+		return `export const ${key} = \`${escape(minify(contents))}\`;`;
+	});
+
+	await writeFile(pkgFilePath(outPath), out.join('\n\n') + '\n');
+	console.log('Updated ' + outPath);
+}
+
+export function pkgFilePath(localPath = '') {
+	const dirname = fileURLToPath(new URL('.', import.meta.url));
+	return join(dirname, '..', localPath);
+}
+
+export async function readPkgFile(localPath = '') {
+	return readFile(pkgFilePath(localPath), { encoding: 'utf8' });
+}

--- a/test/fs-utils.test.js
+++ b/test/fs-utils.test.js
@@ -1,16 +1,9 @@
-import { deepStrictEqual, match, strictEqual } from 'node:assert';
+import { deepStrictEqual, strictEqual } from 'node:assert';
 import { platform } from 'node:os';
 import { chmod } from 'node:fs/promises';
 import { after, suite, test } from 'node:test';
 
-import {
-	getIndex,
-	getKind,
-	getRealpath,
-	isReadable,
-	readPkgFile,
-	readPkgJson,
-} from '../lib/fs-utils.js';
+import { getIndex, getKind, getRealpath, isReadable, readPkgJson } from '../lib/fs-utils.js';
 import { fsFixture } from './shared.js';
 
 const isWindows = platform() === 'win32';
@@ -86,21 +79,5 @@ suite('fsUtils', async () => {
 			strictEqual(await isReadable(path`section2/link.html`), true);
 			strictEqual(await isReadable(path`blocked/link.txt`), false);
 		}
-	});
-});
-
-suite('readPkg', () => {
-	test('readPkgFile', async () => {
-		const license = await readPkgFile('LICENSE');
-		match(license, /The MIT License/);
-
-		const icons = await readPkgFile('assets/icons.svg');
-		match(icons, / xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
-	});
-
-	test('readPkgJson', async () => {
-		const pkg = await readPkgJson();
-		strictEqual(typeof pkg, 'object');
-		match(pkg.version, /^\d+\.\d+\./);
 	});
 });

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -1,13 +1,18 @@
-import { strictEqual } from 'node:assert';
+import { match, strictEqual } from 'node:assert';
 import { suite, test } from 'node:test';
 
 import { readPkgJson } from '../lib/fs-utils.js';
 
 suite('package.json', async () => {
-	const pkgJson = await readPkgJson();
+	const pkg = readPkgJson();
+
+	test('it has a version number', () => {
+		strictEqual(pkg !== null && typeof pkg, 'object');
+		match(pkg.version, /^\d+\.\d+\./);
+	});
 
 	test('it has no dependencies', () => {
-		const keys = Object.keys(pkgJson);
+		const keys = Object.keys(pkg);
 
 		// no library dependencies
 		strictEqual(keys.includes('dependencies'), false);


### PR DESCRIPTION
When rendering an error page or a directory listing, we read files from the package's `assets` folder, and Deno requires a permission prompt for that.

To avoid this somewhat confusing prompt, we can bundle assets into a JavaScript module, looking like:

```js
export const ASSET_NAME = `<svg>…</svg>`;
// etc.
```

I don’t like that it adds a build step (added to the `prepack` script), but it is what it is.

This change also leads to removing some runtime code, and gives a marginally smaller package.
