### PR TITLE
refactor: remove unused ColorUtils.strip method

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -41,9 +41,6 @@ export class ColorUtils {
 			.map((part, index) => (formats[index] ? this.style(part, formats[index]) : part))
 			.join('');
 	};
-
-	/** @type {(input: string) => string} */
-	strip = stripStyle;
 }
 
 class Logger {
@@ -158,14 +155,6 @@ function pathSuffix(basePath, fullPath) {
 	} else if (fullPath.startsWith(basePath)) {
 		return fullPath.slice(basePath.length);
 	}
-}
-
-/** @type {(input: string) => string} */
-export function stripStyle(input) {
-	if (typeof input === 'string' && input.includes('\x1b[')) {
-		return input.replace(/\x1b\[\d+m/g, '');
-	}
-	return input;
 }
 
 /**

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,7 +1,8 @@
 import { strictEqual } from 'node:assert';
 import { suite, test } from 'node:test';
+import { stripVTControlCharacters } from 'node:util';
 
-import { ColorUtils, requestLogLine, stripStyle } from '../lib/logger.js';
+import { ColorUtils, requestLogLine } from '../lib/logger.js';
 
 suite('ColorUtils', () => {
 	const color = new ColorUtils(true);
@@ -34,14 +35,6 @@ suite('ColorUtils', () => {
 		strictEqual(noColor.sequence(['TE', 'ST'], 'blue,red,green'), 'TEST');
 	});
 
-	test('.strip removes formatting', () => {
-		strictEqual(color.strip(color.style('TEST', 'magentaBright')), 'TEST');
-		strictEqual(
-			color.strip(color.sequence(['T', 'E', 'S', 'T'], 'inverse,blink,bold,red')),
-			'TEST',
-		);
-	});
-
 	test('.brackets adds characters around input', () => {
 		strictEqual(color.brackets('TEST', ''), '[TEST]');
 		strictEqual(color.brackets('TEST', '', ['<<<', '>>>']), '<<<TEST>>>');
@@ -62,7 +55,7 @@ suite('responseLogLine', () => {
 			url: `http://localhost:8080${data.urlPath}`,
 			...data,
 		});
-		const line = stripStyle(rawLine).replace(/^\d{2}:\d{2}:\d{2} /, '');
+		const line = stripVTControlCharacters(rawLine).replace(/^\d{2}:\d{2}:\d{2} /, '');
 		strictEqual(line, expected);
 	};
 


### PR DESCRIPTION
We were only using this custom method in tests, and we can use Node's `util.stripVTControlCharacters` for the same purpose.