### PR TITLE
config(ci): run tests on multiple node versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: CI
 
 on:
   push:
@@ -7,14 +7,26 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: Run tests
+  check-types:
     runs-on: ubuntu-latest
+    name: Check types
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
+      - run: npm ci
+      - run: npm run typecheck
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+    name: Run tests on Node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm test
-      - run: npm run typecheck


### PR DESCRIPTION
Ideally we'd run tests on Node 18, but our test suite uses the `suite` function from `node:test`, which is only available in Node 20+.

Node 20 + 22 is last two LTS anyway, and I’m only trying to support 18 for compatibility with StackBlitz. Hopefully they update to Node 20 or later soon enough.