### PR TITLE
fix: improved validation for some options

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const SUPPORTED_METHODS = ['GET', 'HEAD', 'OPTIONS', 'POST'];
 
 export const MAX_COMPRESS_SIZE = 50_000_000;
 
-export const DEFAULT_OPTIONS: Omit<ServerOptions, 'root'> = {
+export const DEFAULT_OPTIONS: Omit<Required<ServerOptions>, 'root'> = {
 	host: HOSTS_WILDCARD.v6,
 	ports: [8080, 8081, 8082, 8083, 8084, 8085, 8086, 8087, 8088, 8089],
 	gzip: true,

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -8,7 +8,14 @@ import { getContentType, typeForFilePath } from './content-type.js';
 import { getLocalPath, isSubpath } from './fs-utils.js';
 import { dirListPage, errorPage } from './pages.js';
 import { PathMatcher } from './path-matcher.js';
-import type { FSLocation, Request, Response, ResMetaData, ServerOptions } from './types.d.ts';
+import type {
+	FSLocation,
+	HttpHeaderRule,
+	Request,
+	Response,
+	ResMetaData,
+	ServerOptions,
+} from './types.d.ts';
 import { headerCase, trimSlash } from './utils.js';
 import { FileResolver } from './resolver.js';
 
@@ -16,7 +23,7 @@ interface Config {
 	req: Request;
 	res: Response;
 	resolver: FileResolver;
-	options: ServerOptions & { _noStream?: boolean };
+	options: Required<ServerOptions> & { _noStream?: boolean };
 }
 
 interface Payload {
@@ -346,11 +353,7 @@ export function extractUrlPath(url: string): string {
 	return path;
 }
 
-export function fileHeaders(
-	localPath: string,
-	rules: ServerOptions['headers'],
-	blockList: string[] = [],
-) {
+export function fileHeaders(localPath: string, rules: HttpHeaderRule[], blockList: string[] = []) {
 	const result: Array<{ name: string; value: string }> = [];
 	for (const rule of rules) {
 		if (Array.isArray(rule.include)) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -44,20 +44,15 @@ export interface ResMetaData {
 	error?: Error | string;
 }
 
-export interface HttpOptions {
-	host: string;
-	ports: number[];
-	headers: HttpHeaderRule[];
-	cors: boolean;
-	gzip: boolean;
-}
-
-export interface ResolveOptions {
+export interface ServerOptions {
 	root: string;
-	ext: string[];
-	dirFile: string[];
-	dirList: boolean;
-	exclude: string[];
+	ext?: string[];
+	dirFile?: string[];
+	dirList?: boolean;
+	exclude?: string[];
+	host?: string;
+	ports?: number[];
+	headers?: HttpHeaderRule[];
+	cors?: boolean;
+	gzip?: boolean;
 }
-
-export type ServerOptions = HttpOptions & ResolveOptions;

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -16,14 +16,6 @@ function checkHeaders(actual: ResponseHeaders, expected: ResponseHeaders) {
 	expect(actual).toEqual(expected);
 }
 
-function headersObj(data: ResponseHeaders) {
-	const result: ResponseHeaders = Object.create(null);
-	for (const [key, value] of Object.entries(data)) {
-		result[key.toLowerCase()] = value;
-	}
-	return result;
-}
-
 function mockReqRes(method: string, url: string, headers: Record<string, string | string[]> = {}) {
 	const req = new IncomingMessage(
 		// @ts-expect-error (we don't have a socket, hoping this is enough for testing)
@@ -39,7 +31,7 @@ function mockReqRes(method: string, url: string, headers: Record<string, string 
 }
 
 function handlerContext(
-	options: ServerOptions,
+	options: Required<ServerOptions>,
 ): (method: string, url: string, headers?: Record<string, string | string[]>) => RequestHandler {
 	const resolver = new FileResolver(options);
 	const handlerOptions = { ...options, gzip: false, _noStream: true };

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -22,7 +22,7 @@ export async function fsFixture(fileTree: import('fs-fixture').FileTree) {
 	return { fileTree, fixture, ...testPathUtils(fixture.path) };
 }
 
-export function getBlankOptions(root?: string): ServerOptions {
+export function getBlankOptions(root?: string): Required<ServerOptions> {
 	return {
 		root: root ?? loc.path(),
 		host: '::',
@@ -37,7 +37,7 @@ export function getBlankOptions(root?: string): ServerOptions {
 	};
 }
 
-export function getDefaultOptions(root?: string): ServerOptions {
+export function getDefaultOptions(root?: string): Required<ServerOptions> {
 	return {
 		root: root ?? loc.path(),
 		...DEFAULT_OPTIONS,


### PR DESCRIPTION
- Make `ServerOptions` type members optional, and use `Required<ServerOptions>` internally.
- Fix some of the `OptionValidator` method logic, and add tests for the `OptionValidator` class.
