### PR TITLE
refactor!: remove empty lib/index.js entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode
 /lib
 /node_modules
 /*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
 				"servitsy": "bin/servitsy.js"
 			},
 			"devDependencies": {
-				"@types/node": "^20.17.9",
+				"@types/node": "^22.10.2",
 				"fs-fixture": "^2.6.0",
 				"linkedom": "^0.18.5",
-				"prettier": "^3.4.1",
+				"prettier": "^3.4.2",
 				"typescript": "~5.7.2",
 				"vitest": "^2.1.8"
 			}
@@ -678,13 +678,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.17.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-			"integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+			"version": "22.10.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+			"integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.19.2"
+				"undici-types": "~6.20.0"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -1236,9 +1236,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
-			"integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+			"integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1386,9 +1386,9 @@
 			"license": "ISC"
 		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -20,14 +20,8 @@
 		"url": "https://www.npmjs.com/~fvsch"
 	},
 	"type": "module",
-	"main": "./lib/index.js",
 	"bin": {
 		"servitsy": "bin/servitsy.js"
-	},
-	"exports": {
-		".": {
-			"import": "./lib/index.js"
-		}
 	},
 	"files": [
 		"./lib",
@@ -42,10 +36,10 @@
 		"typecheck": "tsc -p tsconfig.json --noEmit && tsc -p test/tsconfig.json --noEmit"
 	},
 	"devDependencies": {
-		"@types/node": "^20.17.9",
+		"@types/node": "^22.10.2",
 		"fs-fixture": "^2.6.0",
 		"linkedom": "^0.18.5",
-		"prettier": "^3.4.1",
+		"prettier": "^3.4.2",
 		"typescript": "~5.7.2",
 		"vitest": "^2.1.8"
 	}


### PR DESCRIPTION
From the start of this package, I had the intention of maybe adding a JS API, and had created an empty `lib/index.js` module referenced in `package.json`.

I've done some work along those lines, but it's not ready for 0.5, and I don't think advertising an entry point that doesn't export anything is a good thing.

This is technically a breaking change because before this change you could do:

```js
import "servitsy";
import * as servitsy from "servitsy";
```

and now these might result in errors in some runtimes?