### PR TITLE
chore: update to TypeScript 5.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
 				"servitsy": "bin/servitsy.js"
 			},
 			"devDependencies": {
-				"@types/node": "^22.10.10",
-				"fs-fixture": "^2.6.0",
-				"linkedom": "^0.18.7",
-				"prettier": "^3.4.2",
-				"typescript": "~5.7.3",
-				"vitest": "^3.0.4"
+				"@types/node": "^22.13.9",
+				"fs-fixture": "^2.7.1",
+				"linkedom": "^0.18.9",
+				"prettier": "^3.5.3",
+				"typescript": "~5.8.2",
+				"vitest": "^3.0.8"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-			"integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+			"integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -38,9 +38,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-			"integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+			"integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
 			"cpu": [
 				"arm"
 			],
@@ -55,9 +55,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-			"integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+			"integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
 			"cpu": [
 				"arm64"
 			],
@@ -72,9 +72,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-			"integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+			"integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
 			"cpu": [
 				"x64"
 			],
@@ -89,9 +89,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-			"integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+			"integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
 			"cpu": [
 				"arm64"
 			],
@@ -106,9 +106,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-			"integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+			"integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
 			"cpu": [
 				"x64"
 			],
@@ -123,9 +123,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+			"integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
 			"cpu": [
 				"arm64"
 			],
@@ -140,9 +140,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-			"integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+			"integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
 			"cpu": [
 				"x64"
 			],
@@ -157,9 +157,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-			"integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+			"integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
 			"cpu": [
 				"arm"
 			],
@@ -174,9 +174,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-			"integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+			"integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -191,9 +191,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-			"integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+			"integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
 			"cpu": [
 				"ia32"
 			],
@@ -208,9 +208,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-			"integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+			"integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
 			"cpu": [
 				"loong64"
 			],
@@ -225,9 +225,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-			"integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+			"integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -242,9 +242,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-			"integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+			"integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -259,9 +259,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-			"integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+			"integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -276,9 +276,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-			"integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+			"integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
 			"cpu": [
 				"s390x"
 			],
@@ -293,9 +293,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-			"integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+			"integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
 			"cpu": [
 				"x64"
 			],
@@ -310,9 +310,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+			"integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -327,9 +327,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-			"integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+			"integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
 			"cpu": [
 				"x64"
 			],
@@ -344,9 +344,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+			"integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
 			"cpu": [
 				"arm64"
 			],
@@ -361,9 +361,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-			"integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+			"integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
 			"cpu": [
 				"x64"
 			],
@@ -378,9 +378,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-			"integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+			"integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
 			"cpu": [
 				"x64"
 			],
@@ -395,9 +395,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-			"integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+			"integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
 			"cpu": [
 				"arm64"
 			],
@@ -412,9 +412,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-			"integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+			"integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
 			"cpu": [
 				"ia32"
 			],
@@ -429,9 +429,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-			"integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+			"integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
 			"cpu": [
 				"x64"
 			],
@@ -453,9 +453,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.0.tgz",
-			"integrity": "sha512-G2fUQQANtBPsNwiVFg4zKiPQyjVKZCUdQUol53R8E71J7AsheRMV/Yv/nB8giOcOVqP7//eB5xPqieBYZe9bGg==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
+			"integrity": "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==",
 			"cpu": [
 				"arm"
 			],
@@ -467,9 +467,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.32.0.tgz",
-			"integrity": "sha512-qhFwQ+ljoymC+j5lXRv8DlaJYY/+8vyvYmVx074zrLsu5ZGWYsJNLjPPVJJjhZQpyAKUGPydOq9hRLLNvh1s3A==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.9.tgz",
+			"integrity": "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==",
 			"cpu": [
 				"arm64"
 			],
@@ -481,9 +481,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.32.0.tgz",
-			"integrity": "sha512-44n/X3lAlWsEY6vF8CzgCx+LQaoqWGN7TzUfbJDiTIOjJm4+L2Yq+r5a8ytQRGyPqgJDs3Rgyo8eVL7n9iW6AQ==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
+			"integrity": "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -495,9 +495,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.32.0.tgz",
-			"integrity": "sha512-F9ct0+ZX5Np6+ZDztxiGCIvlCaW87HBdHcozUfsHnj1WCUTBUubAoanhHUfnUHZABlElyRikI0mgcw/qdEm2VQ==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
+			"integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
 			"cpu": [
 				"x64"
 			],
@@ -509,9 +509,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.32.0.tgz",
-			"integrity": "sha512-JpsGxLBB2EFXBsTLHfkZDsXSpSmKD3VxXCgBQtlPcuAqB8TlqtLcbeMhxXQkCDv1avgwNjF8uEIbq5p+Cee0PA==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.9.tgz",
+			"integrity": "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==",
 			"cpu": [
 				"arm64"
 			],
@@ -523,9 +523,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.32.0.tgz",
-			"integrity": "sha512-wegiyBT6rawdpvnD9lmbOpx5Sph+yVZKHbhnSP9MqUEDX08G4UzMU+D87jrazGE7lRSyTRs6NEYHtzfkJ3FjjQ==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.9.tgz",
+			"integrity": "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==",
 			"cpu": [
 				"x64"
 			],
@@ -537,9 +537,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.32.0.tgz",
-			"integrity": "sha512-3pA7xecItbgOs1A5H58dDvOUEboG5UfpTq3WzAdF54acBbUM+olDJAPkgj1GRJ4ZqE12DZ9/hNS2QZk166v92A==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.9.tgz",
+			"integrity": "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==",
 			"cpu": [
 				"arm"
 			],
@@ -551,9 +551,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.32.0.tgz",
-			"integrity": "sha512-Y7XUZEVISGyge51QbYyYAEHwpGgmRrAxQXO3siyYo2kmaj72USSG8LtlQQgAtlGfxYiOwu+2BdbPjzEpcOpRmQ==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.9.tgz",
+			"integrity": "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==",
 			"cpu": [
 				"arm"
 			],
@@ -565,9 +565,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.32.0.tgz",
-			"integrity": "sha512-r7/OTF5MqeBrZo5omPXcTnjvv1GsrdH8a8RerARvDFiDwFpDVDnJyByYM/nX+mvks8XXsgPUxkwe/ltaX2VH7w==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
+			"integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
 			"cpu": [
 				"arm64"
 			],
@@ -579,9 +579,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.32.0.tgz",
-			"integrity": "sha512-HJbifC9vex9NqnlodV2BHVFNuzKL5OnsV2dvTw6e1dpZKkNjPG6WUq+nhEYV6Hv2Bv++BXkwcyoGlXnPrjAKXw==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
+			"integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
 			"cpu": [
 				"arm64"
 			],
@@ -593,9 +593,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.32.0.tgz",
-			"integrity": "sha512-VAEzZTD63YglFlWwRj3taofmkV1V3xhebDXffon7msNz4b14xKsz7utO6F8F4cqt8K/ktTl9rm88yryvDpsfOw==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.9.tgz",
+			"integrity": "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==",
 			"cpu": [
 				"loong64"
 			],
@@ -607,9 +607,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.32.0.tgz",
-			"integrity": "sha512-Sts5DST1jXAc9YH/iik1C9QRsLcCoOScf3dfbY5i4kH9RJpKxiTBXqm7qU5O6zTXBTEZry69bGszr3SMgYmMcQ==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.9.tgz",
+			"integrity": "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -621,9 +621,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.32.0.tgz",
-			"integrity": "sha512-qhlXeV9AqxIyY9/R1h1hBD6eMvQCO34ZmdYvry/K+/MBs6d1nRFLm6BOiITLVI+nFAAB9kUB6sdJRKyVHXnqZw==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.9.tgz",
+			"integrity": "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -635,9 +635,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.32.0.tgz",
-			"integrity": "sha512-8ZGN7ExnV0qjXa155Rsfi6H8M4iBBwNLBM9lcVS+4NcSzOFaNqmt7djlox8pN1lWrRPMRRQ8NeDlozIGx3Omsw==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.9.tgz",
+			"integrity": "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -649,9 +649,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.32.0.tgz",
-			"integrity": "sha512-VDzNHtLLI5s7xd/VubyS10mq6TxvZBp+4NRWoW+Hi3tgV05RtVm4qK99+dClwTN1McA6PHwob6DEJ6PlXbY83A==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
+			"integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
 			"cpu": [
 				"x64"
 			],
@@ -663,9 +663,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.32.0.tgz",
-			"integrity": "sha512-qcb9qYDlkxz9DxJo7SDhWxTWV1gFuwznjbTiov289pASxlfGbaOD54mgbs9+z94VwrXtKTu+2RqwlSTbiOqxGg==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
+			"integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
 			"cpu": [
 				"x64"
 			],
@@ -677,9 +677,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.32.0.tgz",
-			"integrity": "sha512-pFDdotFDMXW2AXVbfdUEfidPAk/OtwE/Hd4eYMTNVVaCQ6Yl8et0meDaKNL63L44Haxv4UExpv9ydSf3aSayDg==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
+			"integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -691,9 +691,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.32.0.tgz",
-			"integrity": "sha512-/TG7WfrCAjeRNDvI4+0AAMoHxea/USWhAzf9PVDFHbcqrQ7hMMKp4jZIy4VEjk72AAfN5k4TiSMRXRKf/0akSw==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.9.tgz",
+			"integrity": "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==",
 			"cpu": [
 				"ia32"
 			],
@@ -705,9 +705,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.32.0.tgz",
-			"integrity": "sha512-5hqO5S3PTEO2E5VjCePxv40gIgyS2KvO7E7/vvC/NbIW4SIRamkMr1hqj+5Y67fbBWv/bQLB6KelBQmXlyCjWA==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
+			"integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
 			"cpu": [
 				"x64"
 			],
@@ -726,9 +726,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.10.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-			"integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+			"version": "22.13.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
+			"integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -736,15 +736,15 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.4.tgz",
-			"integrity": "sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.8.tgz",
+			"integrity": "sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "3.0.4",
-				"@vitest/utils": "3.0.4",
-				"chai": "^5.1.2",
+				"@vitest/spy": "3.0.8",
+				"@vitest/utils": "3.0.8",
+				"chai": "^5.2.0",
 				"tinyrainbow": "^2.0.0"
 			},
 			"funding": {
@@ -752,13 +752,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.4.tgz",
-			"integrity": "sha512-gEef35vKafJlfQbnyOXZ0Gcr9IBUsMTyTLXsEQwuyYAerpHqvXhzdBnDFuHLpFqth3F7b6BaFr4qV/Cs1ULx5A==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.8.tgz",
+			"integrity": "sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "3.0.4",
+				"@vitest/spy": "3.0.8",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.17"
 			},
@@ -779,9 +779,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.4.tgz",
-			"integrity": "sha512-ts0fba+dEhK2aC9PFuZ9LTpULHpY/nd6jhAQ5IMU7Gaj7crPCTdCFfgvXxruRBLFS+MLraicCuFXxISEq8C93g==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.8.tgz",
+			"integrity": "sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -792,38 +792,38 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.4.tgz",
-			"integrity": "sha512-dKHzTQ7n9sExAcWH/0sh1elVgwc7OJ2lMOBrAm73J7AH6Pf9T12Zh3lNE1TETZaqrWFXtLlx3NVrLRb5hCK+iw==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.8.tgz",
+			"integrity": "sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "3.0.4",
-				"pathe": "^2.0.2"
+				"@vitest/utils": "3.0.8",
+				"pathe": "^2.0.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.4.tgz",
-			"integrity": "sha512-+p5knMLwIk7lTQkM3NonZ9zBewzVp9EVkVpvNta0/PlFWpiqLaRcF4+33L1it3uRUCh0BGLOaXPPGEjNKfWb4w==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.8.tgz",
+			"integrity": "sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.0.4",
+				"@vitest/pretty-format": "3.0.8",
 				"magic-string": "^0.30.17",
-				"pathe": "^2.0.2"
+				"pathe": "^2.0.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.4.tgz",
-			"integrity": "sha512-sXIMF0oauYyUy2hN49VFTYodzEAu744MmGcPR3ZBsPM20G+1/cSW/n1U+3Yu/zHxX2bIDe1oJASOkml+osTU6Q==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.8.tgz",
+			"integrity": "sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -834,14 +834,14 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.4.tgz",
-			"integrity": "sha512-8BqC1ksYsHtbWH+DfpOAKrFw3jl3Uf9J7yeFh85Pz52IWuh1hBBtyfEbRNNZNjl8H8A5yMLH9/t+k7HIKzQcZQ==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.8.tgz",
+			"integrity": "sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "3.0.4",
-				"loupe": "^3.1.2",
+				"@vitest/pretty-format": "3.0.8",
+				"loupe": "^3.1.3",
 				"tinyrainbow": "^2.0.0"
 			},
 			"funding": {
@@ -876,9 +876,9 @@
 			}
 		},
 		"node_modules/chai": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-			"integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+			"integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1047,9 +1047,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-			"integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+			"integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1060,31 +1060,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.24.2",
-				"@esbuild/android-arm": "0.24.2",
-				"@esbuild/android-arm64": "0.24.2",
-				"@esbuild/android-x64": "0.24.2",
-				"@esbuild/darwin-arm64": "0.24.2",
-				"@esbuild/darwin-x64": "0.24.2",
-				"@esbuild/freebsd-arm64": "0.24.2",
-				"@esbuild/freebsd-x64": "0.24.2",
-				"@esbuild/linux-arm": "0.24.2",
-				"@esbuild/linux-arm64": "0.24.2",
-				"@esbuild/linux-ia32": "0.24.2",
-				"@esbuild/linux-loong64": "0.24.2",
-				"@esbuild/linux-mips64el": "0.24.2",
-				"@esbuild/linux-ppc64": "0.24.2",
-				"@esbuild/linux-riscv64": "0.24.2",
-				"@esbuild/linux-s390x": "0.24.2",
-				"@esbuild/linux-x64": "0.24.2",
-				"@esbuild/netbsd-arm64": "0.24.2",
-				"@esbuild/netbsd-x64": "0.24.2",
-				"@esbuild/openbsd-arm64": "0.24.2",
-				"@esbuild/openbsd-x64": "0.24.2",
-				"@esbuild/sunos-x64": "0.24.2",
-				"@esbuild/win32-arm64": "0.24.2",
-				"@esbuild/win32-ia32": "0.24.2",
-				"@esbuild/win32-x64": "0.24.2"
+				"@esbuild/aix-ppc64": "0.25.0",
+				"@esbuild/android-arm": "0.25.0",
+				"@esbuild/android-arm64": "0.25.0",
+				"@esbuild/android-x64": "0.25.0",
+				"@esbuild/darwin-arm64": "0.25.0",
+				"@esbuild/darwin-x64": "0.25.0",
+				"@esbuild/freebsd-arm64": "0.25.0",
+				"@esbuild/freebsd-x64": "0.25.0",
+				"@esbuild/linux-arm": "0.25.0",
+				"@esbuild/linux-arm64": "0.25.0",
+				"@esbuild/linux-ia32": "0.25.0",
+				"@esbuild/linux-loong64": "0.25.0",
+				"@esbuild/linux-mips64el": "0.25.0",
+				"@esbuild/linux-ppc64": "0.25.0",
+				"@esbuild/linux-riscv64": "0.25.0",
+				"@esbuild/linux-s390x": "0.25.0",
+				"@esbuild/linux-x64": "0.25.0",
+				"@esbuild/netbsd-arm64": "0.25.0",
+				"@esbuild/netbsd-x64": "0.25.0",
+				"@esbuild/openbsd-arm64": "0.25.0",
+				"@esbuild/openbsd-x64": "0.25.0",
+				"@esbuild/sunos-x64": "0.25.0",
+				"@esbuild/win32-arm64": "0.25.0",
+				"@esbuild/win32-ia32": "0.25.0",
+				"@esbuild/win32-x64": "0.25.0"
 			}
 		},
 		"node_modules/estree-walker": {
@@ -1098,9 +1098,9 @@
 			}
 		},
 		"node_modules/expect-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
-			"integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
+			"integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1108,9 +1108,9 @@
 			}
 		},
 		"node_modules/fs-fixture": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/fs-fixture/-/fs-fixture-2.6.0.tgz",
-			"integrity": "sha512-XQNHBGYgth08BSgThjQNrUuzE9XUmr7CDgGFStKaAeB9Oq+kxUHd1zS6hp1YO11B501Sjv9Jq+B2VFn+CdwmIg==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/fs-fixture/-/fs-fixture-2.7.1.tgz",
+			"integrity": "sha512-fh9PEM+vCFvO8zPztFRW0c8kcG67AfDZ1aMfMO9i2dKFd2WpeNtmZyTDjfmB7AyPRWDPo+NcBj5Ng2llTS7SFA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1143,9 +1143,9 @@
 			"license": "MIT"
 		},
 		"node_modules/htmlparser2": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-			"integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+			"integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
 			"dev": true,
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
@@ -1158,28 +1158,41 @@
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.3",
-				"domutils": "^3.1.0",
-				"entities": "^4.5.0"
+				"domutils": "^3.2.1",
+				"entities": "^6.0.0"
+			}
+		},
+		"node_modules/htmlparser2/node_modules/entities": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+			"integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/linkedom": {
-			"version": "0.18.7",
-			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.7.tgz",
-			"integrity": "sha512-M8XBnWzYG5YckEQgySyIb1Cjh9QarGVxCm+ihTUgcvfbuiLG23748Om6da910yzLMff3wKEvPnZyFo/rhsmFhg==",
+			"version": "0.18.9",
+			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.9.tgz",
+			"integrity": "sha512-Pfvhwjs46nBrcQdauQjMXDJZqj6VwN7KStT84xQqmIgD9bPH6UVJ/ESW8y4VHVF2h7di0/P+f4Iln4U5emRcmg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"css-select": "^5.1.0",
 				"cssom": "^0.5.0",
 				"html-escaper": "^3.0.3",
-				"htmlparser2": "^9.1.0",
+				"htmlparser2": "^10.0.0",
 				"uhyphen": "^0.2.0"
 			}
 		},
 		"node_modules/loupe": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-			"integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+			"integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1233,9 +1246,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
-			"integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1257,9 +1270,9 @@
 			"license": "ISC"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-			"integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -1286,9 +1299,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-			"integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1302,9 +1315,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.32.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.32.0.tgz",
-			"integrity": "sha512-JmrhfQR31Q4AuNBjjAX4s+a/Pu/Q8Q9iwjWBsjRH1q52SPFE2NqRMK6fUZKKnvKO6id+h7JIRf0oYsph53eATg==",
+			"version": "4.34.9",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
+			"integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1318,25 +1331,25 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.32.0",
-				"@rollup/rollup-android-arm64": "4.32.0",
-				"@rollup/rollup-darwin-arm64": "4.32.0",
-				"@rollup/rollup-darwin-x64": "4.32.0",
-				"@rollup/rollup-freebsd-arm64": "4.32.0",
-				"@rollup/rollup-freebsd-x64": "4.32.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.32.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.32.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.32.0",
-				"@rollup/rollup-linux-arm64-musl": "4.32.0",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.32.0",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.32.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.32.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.32.0",
-				"@rollup/rollup-linux-x64-gnu": "4.32.0",
-				"@rollup/rollup-linux-x64-musl": "4.32.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.32.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.32.0",
-				"@rollup/rollup-win32-x64-msvc": "4.32.0",
+				"@rollup/rollup-android-arm-eabi": "4.34.9",
+				"@rollup/rollup-android-arm64": "4.34.9",
+				"@rollup/rollup-darwin-arm64": "4.34.9",
+				"@rollup/rollup-darwin-x64": "4.34.9",
+				"@rollup/rollup-freebsd-arm64": "4.34.9",
+				"@rollup/rollup-freebsd-x64": "4.34.9",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.34.9",
+				"@rollup/rollup-linux-arm-musleabihf": "4.34.9",
+				"@rollup/rollup-linux-arm64-gnu": "4.34.9",
+				"@rollup/rollup-linux-arm64-musl": "4.34.9",
+				"@rollup/rollup-linux-loongarch64-gnu": "4.34.9",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.34.9",
+				"@rollup/rollup-linux-riscv64-gnu": "4.34.9",
+				"@rollup/rollup-linux-s390x-gnu": "4.34.9",
+				"@rollup/rollup-linux-x64-gnu": "4.34.9",
+				"@rollup/rollup-linux-x64-musl": "4.34.9",
+				"@rollup/rollup-win32-arm64-msvc": "4.34.9",
+				"@rollup/rollup-win32-ia32-msvc": "4.34.9",
+				"@rollup/rollup-win32-x64-msvc": "4.34.9",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -1365,9 +1378,9 @@
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
-			"integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
+			"integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1416,9 +1429,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1444,15 +1457,15 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-			"integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.1.tgz",
+			"integrity": "sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.24.2",
-				"postcss": "^8.4.49",
-				"rollup": "^4.23.0"
+				"esbuild": "^0.25.0",
+				"postcss": "^8.5.3",
+				"rollup": "^4.30.1"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -1516,16 +1529,16 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.4.tgz",
-			"integrity": "sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.8.tgz",
+			"integrity": "sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cac": "^6.7.14",
 				"debug": "^4.4.0",
 				"es-module-lexer": "^1.6.0",
-				"pathe": "^2.0.2",
+				"pathe": "^2.0.3",
 				"vite": "^5.0.0 || ^6.0.0"
 			},
 			"bin": {
@@ -1539,31 +1552,31 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.4.tgz",
-			"integrity": "sha512-6XG8oTKy2gnJIFTHP6LD7ExFeNLxiTkK3CfMvT7IfR8IN+BYICCf0lXUQmX7i7JoxUP8QmeP4mTnWXgflu4yjw==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.8.tgz",
+			"integrity": "sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "3.0.4",
-				"@vitest/mocker": "3.0.4",
-				"@vitest/pretty-format": "^3.0.4",
-				"@vitest/runner": "3.0.4",
-				"@vitest/snapshot": "3.0.4",
-				"@vitest/spy": "3.0.4",
-				"@vitest/utils": "3.0.4",
-				"chai": "^5.1.2",
+				"@vitest/expect": "3.0.8",
+				"@vitest/mocker": "3.0.8",
+				"@vitest/pretty-format": "^3.0.8",
+				"@vitest/runner": "3.0.8",
+				"@vitest/snapshot": "3.0.8",
+				"@vitest/spy": "3.0.8",
+				"@vitest/utils": "3.0.8",
+				"chai": "^5.2.0",
 				"debug": "^4.4.0",
 				"expect-type": "^1.1.0",
 				"magic-string": "^0.30.17",
-				"pathe": "^2.0.2",
+				"pathe": "^2.0.3",
 				"std-env": "^3.8.0",
 				"tinybench": "^2.9.0",
 				"tinyexec": "^0.3.2",
 				"tinypool": "^1.0.2",
 				"tinyrainbow": "^2.0.0",
 				"vite": "^5.0.0 || ^6.0.0",
-				"vite-node": "3.0.4",
+				"vite-node": "3.0.8",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -1579,8 +1592,8 @@
 				"@edge-runtime/vm": "*",
 				"@types/debug": "^4.1.12",
 				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-				"@vitest/browser": "3.0.4",
-				"@vitest/ui": "3.0.4",
+				"@vitest/browser": "3.0.8",
+				"@vitest/ui": "3.0.8",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
 		"typecheck": "tsc -p tsconfig.json --noEmit && tsc -p test/tsconfig.json --noEmit"
 	},
 	"devDependencies": {
-		"@types/node": "^22.10.10",
-		"fs-fixture": "^2.6.0",
-		"linkedom": "^0.18.7",
-		"prettier": "^3.4.2",
-		"typescript": "~5.7.3",
-		"vitest": "^3.0.4"
+		"@types/node": "^22.13.9",
+		"fs-fixture": "^2.7.1",
+		"linkedom": "^0.18.9",
+		"prettier": "^3.5.3",
+		"typescript": "~5.8.2",
+		"vitest": "^3.0.8"
 	}
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -218,11 +218,12 @@ export class RequestHandler {
 
 		// Send file contents if already available
 		if (typeof body === 'string' || Buffer.isBuffer(body)) {
-			const buf = compress ? gzipSync(body) : Buffer.from(body);
-			this.#header('content-length', buf.byteLength);
+			let buf = typeof body === 'string' ? Buffer.from(body) : body;
 			if (compress) {
+				buf = gzipSync(buf);
 				this.#header('content-encoding', 'gzip');
 			}
+			this.#header('content-length', buf.byteLength);
 			if (!isHead) {
 				this.#res.write(buf);
 			}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -7,8 +7,9 @@
 		"types": ["node"],
 		"strict": true,
 		"skipLibCheck": true,
-		"isolatedModules": true,
 		"allowImportingTsExtensions": true,
+		"isolatedModules": true,
+		"erasableSyntaxOnly": true,
 		"noEmit": true
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,13 @@
 		"target": "ES2022",
 		"lib": ["ES2022"],
 		"types": ["node"],
-		"strict": true,
-		"isolatedModules": true,
 		"outDir": "./lib",
+		"strict": true,
 		"allowImportingTsExtensions": true,
+		"erasableSyntaxOnly": true,
+		"isolatedModules": true,
+		"removeComments": true,
 		"rewriteRelativeImportExtensions": true,
-		"removeComments": true
+		"verbatimModuleSyntax": true
 	}
 }


### PR DESCRIPTION
Use TypeScript 5.8 with the `erasableSyntaxOnly` compiler option, to ensure compatibility with Node 22's `--experimental-strip-types`.